### PR TITLE
fix(ci): skip governance checks for dependabot and renovate PRs

### DIFF
--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.head_ref, 'dependabot/') && !startsWith(github.head_ref, 'renovate/') }}
     steps:
       - name: Validate PR description sections
         uses: actions/github-script@v7

--- a/.github/workflows/require-issue-reference.yml
+++ b/.github/workflows/require-issue-reference.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   require-issue:
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.head_ref, 'dependabot/') && !startsWith(github.head_ref, 'renovate/') }}
     steps:
       - name: Check PR description for issue reference
         uses: actions/github-script@v7
@@ -17,7 +18,7 @@ jobs:
             const patterns = [
               /closes\s*:?\s+#\d+(?:[.,;!?]|\s|$)/,
               /fixes\s*:?\s+#\d+(?:[.,;!?]|\s|$)/,
-              /resolves\s*:?\s+#\d+(?:[.,;!?]|\s|$)+#\d+(?:[.,;!?]|\s|$)/
+              /resolves\s*:?\s+#\d+(?:[.,;!?]|\s|$)/
             ]
 
             const found = patterns.some(p => p.test(body))

--- a/.github/workflows/validate-branch-flow.yml
+++ b/.github/workflows/validate-branch-flow.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   validate-branch-flow:
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.head_ref, 'dependabot/') && !startsWith(github.head_ref, 'renovate/') }}
     steps:
       - name: Validate source branch naming
         run: |


### PR DESCRIPTION
## Changes

Skip require-issue, PR description validation, and branch-naming validation for automated dependency PRs (dependabot/\*, renovate/\*).

Also fixes a duplicated capture group in the resolves regex of require-issue-reference.yml.

## Motivation

Closes #35

Dependabot and Renovate PRs cannot conform to project branch naming, issue-reference, or PR-description conventions as they are fully automated. The current governance workflows block all automated dependency updates from passing CI.

## Impact

- Dependabot and Renovate PRs will pass governance checks and be mergeable
- Human PRs are unaffected — all governance checks still apply to non-automated branches
- No functional code changes