### PR TITLE
fix(ci): skip commitlint for dependabot and renovate branches

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   commitlint:
+    if: ${{ !startsWith(github.head_ref, 'dependabot/') && !startsWith(github.head_ref, 'renovate/') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Dependabot pip-based PRs use `deps` as the commit type (e.g. `deps(deps-dev): bump ...`). This type is not in our commitlint `type-enum`, causing the `commitlint` CI check to fail on automated PRs.

## Changes

- Consistent with the governance workflow exemptions landed in PR #36

## Motivation

Dependabot pip PRs generate commits like `deps(deps-dev): bump ...` where `deps` is not a valid type in our conventional commit config. These automated PRs cannot be manually adjusted, so the CI check must be skipped for them.

## Impact

- `commitlint` is skipped for all `dependabot/*` and `renovate/*` branches
- Human-authored PRs continue to be enforced normally
- Unblocks PR #30 from merging

## Checklist
- [x] no source changes
- [x] follows existing pattern from PR #36
- [x] closes #37