### PR TITLE
feat(saga): implement saga choreography mode (event-driven sagas)

### DIFF
--- a/docs/architecture/adr/adr-029-saga-choreography.md
+++ b/docs/architecture/adr/adr-029-saga-choreography.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-**Proposed** | Date: 2026-01-10 | Priority: High | Target: v2.2.0
+**In Progress** | Date: 2026-01-10 | Priority: High | Target: v2.2.0
 
 **Implementation Status:**
 - ⚪ Phase 1: Event Bus Infrastructure (Not Started)

--- a/sagaz/choreography/__init__.py
+++ b/sagaz/choreography/__init__.py
@@ -4,15 +4,24 @@ sagaz.choreography — Saga Choreography Pattern.
 Choreography is an alternative to orchestration where services react to events
 independently. Unlike ``Saga`` (which has a central coordinator), a
 ``ChoreographedSaga`` declares event handlers using the ``@on_event`` decorator
-and publishes new events via ``EventBus.publish()``.
+and publishes new events via an ``AbstractEventBus`` implementation.
 
 Public API::
 
     from sagaz.choreography import (
+        AbstractEventBus,
+        BusBackend,
         ChoreographedSaga,
         Event,
         EventBus,
         ChoreographyEngine,
+        KafkaEventBus,
+        KafkaEventBusConfig,
+        RabbitMQEventBus,
+        RabbitMQEventBusConfig,
+        RedisStreamsBusConfig,
+        RedisStreamsEventBus,
+        create_event_bus,
         on_event,
     )
 
@@ -32,29 +41,45 @@ Quick start (in-process bus)::
     await bus.publish(Event("order.created", {"order_id": "ORD-1"}))
     await engine.stop()
 
-Distributed bus (Redis Streams — requires ``sagaz[redis]``)::
+Selecting a broker at runtime::
 
-    from sagaz.choreography import RedisStreamsEventBus, RedisStreamsBusConfig
+    from sagaz.choreography import create_event_bus, BusBackend
 
-    config = RedisStreamsBusConfig(url="redis://localhost:6379/0")
-    bus = RedisStreamsEventBus(config)
-    await bus.start()
-    # ... same engine/saga setup ...
-    await bus.stop()
+    bus = create_event_bus(BusBackend.REDIS)          # Redis Streams
+    bus = create_event_bus(BusBackend.KAFKA)          # Apache Kafka
+    bus = create_event_bus(BusBackend.RABBITMQ)       # RabbitMQ / AMQP
+    bus = create_event_bus(BusBackend.MEMORY)         # in-process (default)
 """
 
-from sagaz.choreography.buses import RedisStreamsBusConfig, RedisStreamsEventBus
+from sagaz.choreography.buses import (
+    BusBackend,
+    KafkaEventBus,
+    KafkaEventBusConfig,
+    RabbitMQEventBus,
+    RabbitMQEventBusConfig,
+    RedisStreamsBusConfig,
+    RedisStreamsEventBus,
+    create_event_bus,
+)
 from sagaz.choreography.decorators import on_event
 from sagaz.choreography.engine import ChoreographyEngine
-from sagaz.choreography.events import Event, EventBus
+from sagaz.choreography.events import AbstractEventBus, Event, EventBus
 from sagaz.choreography.saga import ChoreographedSaga
 
 __all__ = [
+    "AbstractEventBus",
+    "BusBackend",
     "ChoreographedSaga",
     "ChoreographyEngine",
     "Event",
     "EventBus",
+    "KafkaEventBus",
+    "KafkaEventBusConfig",
+    "RabbitMQEventBus",
+    "RabbitMQEventBusConfig",
     "RedisStreamsBusConfig",
     "RedisStreamsEventBus",
+    "create_event_bus",
     "on_event",
 ]
+

--- a/sagaz/choreography/__init__.py
+++ b/sagaz/choreography/__init__.py
@@ -1,0 +1,47 @@
+"""
+sagaz.choreography — Saga Choreography Pattern.
+
+Choreography is an alternative to orchestration where services react to events
+independently. Unlike ``Saga`` (which has a central coordinator), a
+``ChoreographedSaga`` declares event handlers using the ``@on_event`` decorator
+and publishes new events via ``EventBus.publish()``.
+
+Public API::
+
+    from sagaz.choreography import (
+        ChoreographedSaga,
+        Event,
+        EventBus,
+        ChoreographyEngine,
+        on_event,
+    )
+
+Quick start::
+
+    bus = EventBus()
+    engine = ChoreographyEngine(bus)
+
+    class OrderSaga(ChoreographedSaga):
+        @on_event("order.created")
+        async def handle_order_created(self, event: Event) -> None:
+            await bus.publish(Event("inventory.reserve", {"order_id": event.data["order_id"]}))
+
+    saga = OrderSaga()
+    engine.register(saga)
+    await engine.start()
+    await bus.publish(Event("order.created", {"order_id": "ORD-1"}))
+    await engine.stop()
+"""
+
+from sagaz.choreography.decorators import on_event
+from sagaz.choreography.engine import ChoreographyEngine
+from sagaz.choreography.events import Event, EventBus
+from sagaz.choreography.saga import ChoreographedSaga
+
+__all__ = [
+    "ChoreographedSaga",
+    "ChoreographyEngine",
+    "Event",
+    "EventBus",
+    "on_event",
+]

--- a/sagaz/choreography/__init__.py
+++ b/sagaz/choreography/__init__.py
@@ -16,7 +16,7 @@ Public API::
         on_event,
     )
 
-Quick start::
+Quick start (in-process bus)::
 
     bus = EventBus()
     engine = ChoreographyEngine(bus)
@@ -31,8 +31,19 @@ Quick start::
     await engine.start()
     await bus.publish(Event("order.created", {"order_id": "ORD-1"}))
     await engine.stop()
+
+Distributed bus (Redis Streams — requires ``sagaz[redis]``)::
+
+    from sagaz.choreography import RedisStreamsEventBus, RedisStreamsBusConfig
+
+    config = RedisStreamsBusConfig(url="redis://localhost:6379/0")
+    bus = RedisStreamsEventBus(config)
+    await bus.start()
+    # ... same engine/saga setup ...
+    await bus.stop()
 """
 
+from sagaz.choreography.buses import RedisStreamsBusConfig, RedisStreamsEventBus
 from sagaz.choreography.decorators import on_event
 from sagaz.choreography.engine import ChoreographyEngine
 from sagaz.choreography.events import Event, EventBus
@@ -43,5 +54,7 @@ __all__ = [
     "ChoreographyEngine",
     "Event",
     "EventBus",
+    "RedisStreamsBusConfig",
+    "RedisStreamsEventBus",
     "on_event",
 ]

--- a/sagaz/choreography/__init__.py
+++ b/sagaz/choreography/__init__.py
@@ -82,4 +82,3 @@ __all__ = [
     "create_event_bus",
     "on_event",
 ]
-

--- a/sagaz/choreography/buses/__init__.py
+++ b/sagaz/choreography/buses/__init__.py
@@ -1,7 +1,7 @@
 """
-sagaz.choreography.buses — EventBus transport backends.
+sagaz.choreography.buses — broker-agnostic EventBus transport backends.
 
-Two implementations are provided:
+Four implementations are provided, all sharing the ``AbstractEventBus`` API:
 
 ``EventBus``
     In-process asyncio pub/sub.  Zero dependencies; ideal for single-process
@@ -10,30 +10,44 @@ Two implementations are provided:
 
 ``RedisStreamsEventBus``
     Distributed pub/sub backed by Redis Streams (XADD / XREADGROUP).  Requires
-    only the ``redis`` optional extra — no Kafka or RabbitMQ needed.  Suitable
-    for multi-process / multi-service choreography.
+    the ``redis`` optional extra (``sagaz[redis]``).
 
-Example::
+``KafkaEventBus``
+    Distributed pub/sub backed by Apache Kafka.  Requires the ``aiokafka``
+    optional extra (``sagaz[kafka]``).
 
-    from sagaz.choreography.buses import RedisStreamsEventBus, RedisStreamsBusConfig
+``RabbitMQEventBus``
+    Distributed pub/sub backed by RabbitMQ / AMQP (topic exchange).  Requires
+    the ``aio-pika`` optional extra (``sagaz[rabbitmq]``).
 
-    config = RedisStreamsBusConfig(
-        url="redis://localhost:6379/0",
-        stream_name="sagaz.choreography",
-        consumer_group="my-service",
-        consumer_name="worker-1",
-    )
-    bus = RedisStreamsEventBus(config)
+Use ``create_event_bus(backend)`` to select a backend at runtime::
+
+    from sagaz.choreography.buses import create_event_bus, BusBackend
+
+    bus = create_event_bus(BusBackend.REDIS)
     await bus.start()
-    try:
-        ...
-    finally:
-        await bus.stop()
+    bus.subscribe("order.created", my_handler)
+    await bus.publish(Event("order.created", {"order_id": "ORD-1"}))
+    await bus.stop()
 """
 
+from sagaz.choreography.buses.factory import BusBackend, create_event_bus
+from sagaz.choreography.buses.kafka import KafkaEventBus, KafkaEventBusConfig
+from sagaz.choreography.buses.rabbitmq import RabbitMQEventBus, RabbitMQEventBusConfig
 from sagaz.choreography.buses.redis_streams import (
     RedisStreamsBusConfig,
     RedisStreamsEventBus,
 )
+from sagaz.choreography.events import AbstractEventBus
 
-__all__ = ["RedisStreamsBusConfig", "RedisStreamsEventBus"]
+__all__ = [
+    "AbstractEventBus",
+    "BusBackend",
+    "KafkaEventBus",
+    "KafkaEventBusConfig",
+    "RabbitMQEventBus",
+    "RabbitMQEventBusConfig",
+    "RedisStreamsBusConfig",
+    "RedisStreamsEventBus",
+    "create_event_bus",
+]

--- a/sagaz/choreography/buses/__init__.py
+++ b/sagaz/choreography/buses/__init__.py
@@ -1,0 +1,39 @@
+"""
+sagaz.choreography.buses — EventBus transport backends.
+
+Two implementations are provided:
+
+``InMemoryEventBus``
+    In-process asyncio pub/sub.  Zero dependencies; ideal for single-process
+    sagas, unit tests, and local development.  Imported from
+    ``sagaz.choreography.events`` for backward compatibility.
+
+``RedisStreamsEventBus``
+    Distributed pub/sub backed by Redis Streams (XADD / XREADGROUP).  Requires
+    only the ``redis`` optional extra — no Kafka or RabbitMQ needed.  Suitable
+    for multi-process / multi-service choreography.
+
+Example::
+
+    from sagaz.choreography.buses import RedisStreamsEventBus, RedisStreamsBusConfig
+
+    config = RedisStreamsBusConfig(
+        url="redis://localhost:6379/0",
+        stream_name="sagaz.choreography",
+        consumer_group="my-service",
+        consumer_name="worker-1",
+    )
+    bus = RedisStreamsEventBus(config)
+    await bus.start()
+    try:
+        ...
+    finally:
+        await bus.stop()
+"""
+
+from sagaz.choreography.buses.redis_streams import (
+    RedisStreamsBusConfig,
+    RedisStreamsEventBus,
+)
+
+__all__ = ["RedisStreamsBusConfig", "RedisStreamsEventBus"]

--- a/sagaz/choreography/buses/__init__.py
+++ b/sagaz/choreography/buses/__init__.py
@@ -3,10 +3,10 @@ sagaz.choreography.buses — EventBus transport backends.
 
 Two implementations are provided:
 
-``InMemoryEventBus``
+``EventBus``
     In-process asyncio pub/sub.  Zero dependencies; ideal for single-process
     sagas, unit tests, and local development.  Imported from
-    ``sagaz.choreography.events`` for backward compatibility.
+    ``sagaz.choreography.events``.
 
 ``RedisStreamsEventBus``
     Distributed pub/sub backed by Redis Streams (XADD / XREADGROUP).  Requires

--- a/sagaz/choreography/buses/factory.py
+++ b/sagaz/choreography/buses/factory.py
@@ -1,0 +1,95 @@
+"""
+EventBus factory — create a broker-specific transport from a string key.
+
+Usage::
+
+    from sagaz.choreography.buses import create_event_bus, BusBackend
+
+    # In-process (default, zero dependencies)
+    bus = create_event_bus("memory")
+
+    # Redis Streams (requires sagaz[redis])
+    bus = create_event_bus("redis", RedisStreamsBusConfig(url="redis://localhost:6379/0"))
+
+    # Apache Kafka (requires sagaz[kafka])
+    bus = create_event_bus("kafka", KafkaEventBusConfig(bootstrap_servers="localhost:9092"))
+
+    # RabbitMQ / AMQP (requires sagaz[rabbitmq])
+    bus = create_event_bus("rabbitmq", RabbitMQEventBusConfig(url="amqp://guest:guest@localhost/"))
+
+Or use the ``BusBackend`` enum for type-safe selection::
+
+    bus = create_event_bus(BusBackend.KAFKA)
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any
+
+from sagaz.choreography.events import AbstractEventBus
+
+
+class BusBackend(StrEnum):
+    """Enumeration of supported EventBus transport backends."""
+
+    MEMORY = "memory"
+    REDIS = "redis"
+    KAFKA = "kafka"
+    RABBITMQ = "rabbitmq"
+
+
+def create_event_bus(
+    backend: str | BusBackend,
+    config: Any = None,
+) -> AbstractEventBus:
+    """
+    Instantiate an ``AbstractEventBus`` for the given *backend*.
+
+    Parameters
+    ----------
+    backend:
+        One of ``"memory"``, ``"redis"``, ``"kafka"``, or ``"rabbitmq"``
+        (case-insensitive).  Can also be a ``BusBackend`` enum value.
+    config:
+        Optional backend-specific configuration dataclass.  When *None*,
+        the backend reads from environment variables via ``from_env()``.
+
+    Returns
+    -------
+    AbstractEventBus
+        A concrete bus instance.  Call ``await bus.start()`` before use.
+
+    Raises
+    ------
+    ValueError
+        If *backend* is not a recognised value.
+    MissingDependencyError
+        If the required optional package is not installed.
+    """
+    try:
+        backend = BusBackend(str(backend).lower())
+    except ValueError:
+        valid = [b.value for b in BusBackend]
+        msg = f"Unknown bus backend {backend!r}. Valid values: {valid}"
+        raise ValueError(msg) from None
+
+    if backend is BusBackend.MEMORY:
+        from sagaz.choreography.events import EventBus
+
+        return EventBus()
+
+    if backend is BusBackend.REDIS:
+        from sagaz.choreography.buses.redis_streams import RedisStreamsEventBus
+
+        return RedisStreamsEventBus(config)
+
+    if backend is BusBackend.KAFKA:
+        from sagaz.choreography.buses.kafka import KafkaEventBus
+
+        return KafkaEventBus(config)
+
+    # backend is BusBackend.RABBITMQ
+    from sagaz.choreography.buses.rabbitmq import RabbitMQEventBus
+
+    return RabbitMQEventBus(config)

--- a/sagaz/choreography/buses/kafka.py
+++ b/sagaz/choreography/buses/kafka.py
@@ -1,0 +1,341 @@
+"""
+Kafka EventBus — distributed choreography transport via Apache Kafka.
+
+Uses aiokafka for async producer/consumer.  Each message is written to a
+single configurable topic; the ``event_type`` is used as the Kafka message
+key so that events of the same type land on the same partition.
+
+Architecture
+------------
+- ``publish()`` serialises the ``Event`` to JSON and calls
+  ``AIOKafkaProducer.send_and_wait()``.
+- ``start()`` creates producer + consumer, starts a background reader task.
+- ``stop()`` cancels the reader task, then stops producer and consumer.
+- ``subscribe()`` / ``unsubscribe()`` register/deregister in-process handlers.
+
+Consumer groups
+---------------
+All instances sharing the same ``consumer_group`` load-balance message
+consumption (Kafka's standard consumer group semantics).  Use the same group
+name across replicas of one service; use different group names for different
+service types that each need their own copy of every event (fan-out).
+
+Configuration
+-------------
+All options are exposed through ``KafkaEventBusConfig``.  Environment
+variables follow the ``SAGAZ_BUS_KAFKA_*`` prefix:
+
+    SAGAZ_BUS_KAFKA_BOOTSTRAP_SERVERS   localhost:9092
+    SAGAZ_BUS_KAFKA_TOPIC               sagaz.choreography
+    SAGAZ_BUS_KAFKA_CONSUMER_GROUP      sagaz
+    SAGAZ_BUS_KAFKA_CONSUMER_NAME       worker-1
+    SAGAZ_BUS_KAFKA_SECURITY_PROTOCOL   PLAINTEXT
+    SAGAZ_BUS_KAFKA_SASL_MECHANISM      (PLAIN, SCRAM-SHA-256, …)
+    SAGAZ_BUS_KAFKA_SASL_USERNAME
+    SAGAZ_BUS_KAFKA_SASL_PASSWORD
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from sagaz.choreography.events import AbstractEventBus, Event, HandlerT
+from sagaz.core.exceptions import MissingDependencyError
+
+try:
+    from aiokafka import AIOKafkaConsumer, AIOKafkaProducer  # type: ignore[import-untyped]
+
+    _KAFKA_AVAILABLE = True
+except ImportError:
+    _KAFKA_AVAILABLE = False
+    AIOKafkaProducer: Any = None  # type: ignore[assignment, no-redef]
+    AIOKafkaConsumer: Any = None  # type: ignore[assignment, no-redef]
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class KafkaEventBusConfig:
+    """
+    Configuration for ``KafkaEventBus``.
+
+    Parameters
+    ----------
+    bootstrap_servers:
+        Comma-separated Kafka broker addresses.
+    topic:
+        Kafka topic used as the choreography bus.
+    consumer_group:
+        Consumer group ID shared by all instances of the same service.
+    consumer_name:
+        Unique client identifier within the group (e.g. hostname + pid).
+    auto_offset_reset:
+        Where to start consuming if no committed offset exists
+        (``"latest"`` or ``"earliest"``).
+    max_poll_records:
+        Maximum records fetched per poll.
+    security_protocol:
+        ``PLAINTEXT``, ``SSL``, ``SASL_PLAINTEXT``, or ``SASL_SSL``.
+    sasl_mechanism:
+        SASL mechanism (``PLAIN``, ``SCRAM-SHA-256``, etc.)
+        ``None`` disables SASL.
+    sasl_username:
+        SASL username; used only when ``sasl_mechanism`` is set.
+    sasl_password:
+        SASL password; used only when ``sasl_mechanism`` is set.
+    """
+
+    bootstrap_servers: str = "localhost:9092"
+    topic: str = "sagaz.choreography"
+    consumer_group: str = "sagaz"
+    consumer_name: str = "worker-1"
+    auto_offset_reset: str = "latest"
+    max_poll_records: int = 100
+    security_protocol: str = "PLAINTEXT"
+    sasl_mechanism: str | None = None
+    sasl_username: str | None = None
+    sasl_password: str | None = None
+
+    @classmethod
+    def from_env(cls) -> KafkaEventBusConfig:
+        """Build config from environment variables."""
+        return cls(
+            bootstrap_servers=os.environ.get(
+                "SAGAZ_BUS_KAFKA_BOOTSTRAP_SERVERS", "localhost:9092"
+            ),
+            topic=os.environ.get("SAGAZ_BUS_KAFKA_TOPIC", "sagaz.choreography"),
+            consumer_group=os.environ.get("SAGAZ_BUS_KAFKA_CONSUMER_GROUP", "sagaz"),
+            consumer_name=os.environ.get("SAGAZ_BUS_KAFKA_CONSUMER_NAME", "worker-1"),
+            security_protocol=os.environ.get(
+                "SAGAZ_BUS_KAFKA_SECURITY_PROTOCOL", "PLAINTEXT"
+            ),
+            sasl_mechanism=os.environ.get("SAGAZ_BUS_KAFKA_SASL_MECHANISM"),
+            sasl_username=os.environ.get("SAGAZ_BUS_KAFKA_SASL_USERNAME"),
+            sasl_password=os.environ.get("SAGAZ_BUS_KAFKA_SASL_PASSWORD"),
+        )
+
+
+def _event_to_value(event: Event) -> bytes:
+    """Serialise an ``Event`` to a JSON-encoded bytes value."""
+    return json.dumps(
+        {
+            "event_type": event.event_type,
+            "data": event.data,
+            "event_id": event.event_id,
+            "saga_id": event.saga_id,
+            "created_at": event.created_at.isoformat(),
+        }
+    ).encode()
+
+
+def _value_to_event(value: bytes) -> Event:
+    """Deserialise a Kafka message value back to an ``Event``."""
+    payload = json.loads(value.decode())
+    raw_dt = datetime.fromisoformat(payload["created_at"])
+    created_at = raw_dt.astimezone(UTC) if raw_dt.tzinfo else raw_dt.replace(tzinfo=UTC)
+    return Event(
+        event_type=payload["event_type"],
+        data=payload["data"],
+        event_id=payload["event_id"],
+        saga_id=payload.get("saga_id"),
+        created_at=created_at,
+    )
+
+
+class KafkaEventBus(AbstractEventBus):
+    """
+    Distributed ``EventBus`` backed by Apache Kafka.
+
+    Use ``start()`` before publishing or subscribing, and ``stop()`` on
+    shutdown.  Suitable as a drop-in replacement for the in-process
+    ``EventBus`` when distributed choreography across multiple processes or
+    services is needed.
+
+    Parameters
+    ----------
+    config:
+        ``KafkaEventBusConfig`` instance.  Defaults to ``from_env()``.
+
+    Raises
+    ------
+    MissingDependencyError
+        If the ``aiokafka`` package is not installed.
+    """
+
+    def __init__(self, config: KafkaEventBusConfig | None = None) -> None:
+        if not _KAFKA_AVAILABLE:
+            pkg = "aiokafka"
+            raise MissingDependencyError(pkg, feature="KafkaEventBus")
+        self._config = config or KafkaEventBusConfig.from_env()
+        self._handlers: dict[str, list[HandlerT]] = defaultdict(list)
+        self._producer: Any = None
+        self._consumer: Any = None
+        self._reader_task: asyncio.Task[None] | None = None
+        self._published: list[Event] = []
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Create producer/consumer, connect, and start the reader loop."""
+        if self._reader_task is not None and not self._reader_task.done():
+            return
+
+        producer_kwargs: dict[str, Any] = {
+            "bootstrap_servers": self._config.bootstrap_servers,
+            "client_id": self._config.consumer_name,
+            "acks": "all",
+            "enable_idempotence": True,
+        }
+        consumer_kwargs: dict[str, Any] = {
+            "bootstrap_servers": self._config.bootstrap_servers,
+            "group_id": self._config.consumer_group,
+            "client_id": f"{self._config.consumer_name}-consumer",
+            "auto_offset_reset": self._config.auto_offset_reset,
+            "enable_auto_commit": False,
+        }
+        if self._config.sasl_mechanism:
+            sasl_opts: dict[str, Any] = {
+                "security_protocol": self._config.security_protocol,
+                "sasl_mechanism": self._config.sasl_mechanism,
+                "sasl_plain_username": self._config.sasl_username,
+                "sasl_plain_password": self._config.sasl_password,
+            }
+            producer_kwargs.update(sasl_opts)
+            consumer_kwargs.update(sasl_opts)
+
+        self._producer = AIOKafkaProducer(**producer_kwargs)
+        self._consumer = AIOKafkaConsumer(self._config.topic, **consumer_kwargs)
+        await self._producer.start()
+        await self._consumer.start()
+
+        self._reader_task = asyncio.create_task(
+            self._reader_loop(), name="sagaz-kafka-reader"
+        )
+        logger.info(
+            "KafkaEventBus started (topic=%s, group=%s)",
+            self._config.topic,
+            self._config.consumer_group,
+        )
+
+    async def stop(self) -> None:
+        """Cancel the reader loop and stop the producer/consumer."""
+        if self._reader_task and not self._reader_task.done():
+            self._reader_task.cancel()
+            try:
+                await self._reader_task
+            except asyncio.CancelledError:
+                pass
+            self._reader_task = None
+        if self._consumer is not None:
+            await self._consumer.stop()
+            self._consumer = None
+        if self._producer is not None:
+            await self._producer.stop()
+            self._producer = None
+        logger.info("KafkaEventBus stopped")
+
+    # ------------------------------------------------------------------
+    # Subscription
+    # ------------------------------------------------------------------
+
+    def subscribe(self, event_type: str, handler: HandlerT) -> None:
+        """Register *handler* for *event_type* (or ``"*"`` for all events)."""
+        self._handlers[event_type].append(handler)
+        logger.debug("Subscribed %s to %r", handler, event_type)
+
+    def unsubscribe(self, event_type: str, handler: HandlerT) -> None:
+        """Remove *handler* from *event_type* subscribers."""
+        try:
+            self._handlers[event_type].remove(handler)
+        except ValueError:
+            pass
+
+    # ------------------------------------------------------------------
+    # Publishing
+    # ------------------------------------------------------------------
+
+    async def publish(self, event: Event) -> None:
+        """
+        Publish *event* to the Kafka topic.
+
+        The event is JSON-serialised and sent via ``send_and_wait``; the
+        ``event_type`` is used as the Kafka message key for deterministic
+        partition routing.
+        """
+        if self._producer is None:
+            msg = "Call start() before publish()"
+            raise RuntimeError(msg)
+        value = _event_to_value(event)
+        await self._producer.send_and_wait(
+            self._config.topic,
+            value=value,
+            key=event.event_type.encode(),
+        )
+        self._published.append(event)
+        logger.debug("Published %r to Kafka topic %s", event, self._config.topic)
+
+    # ------------------------------------------------------------------
+    # Reader loop (internal)
+    # ------------------------------------------------------------------
+
+    async def _reader_loop(self) -> None:
+        """Background task: poll Kafka and dispatch to in-process handlers."""
+        while True:
+            try:
+                records = await self._consumer.getmany(
+                    timeout_ms=500,
+                    max_records=self._config.max_poll_records,
+                )
+                for tp, messages in records.items():
+                    for msg in messages:
+                        await self._dispatch(msg.value)
+                        await self._consumer.commit({tp: msg.offset + 1})
+            except asyncio.CancelledError:
+                break
+            except Exception:
+                logger.exception("KafkaEventBus reader error")
+                await asyncio.sleep(0.5)
+
+    async def _dispatch(self, value: bytes) -> None:
+        """Deserialise one Kafka value and invoke matching handlers."""
+        try:
+            event = _value_to_event(value)
+        except Exception:
+            logger.exception("Failed to deserialise Kafka message: %s", value)
+            return
+
+        handlers = list(self._handlers.get(event.event_type, []))
+        handlers += list(self._handlers.get("*", []))
+        for handler in handlers:
+            try:
+                await handler(event)
+            except Exception:
+                logger.exception(
+                    "Handler %s raised on event %r", handler, event.event_type
+                )
+
+    # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+
+    @property
+    def published(self) -> list[Event]:
+        """Events published via this bus instance (for testing/debugging)."""
+        return list(self._published)
+
+    def clear_history(self) -> None:
+        """Discard the recorded publish history."""
+        self._published.clear()
+
+    def handler_count(self, event_type: str) -> int:
+        """Return the number of handlers registered for *event_type*."""
+        return len(self._handlers.get(event_type, []))

--- a/sagaz/choreography/buses/kafka.py
+++ b/sagaz/choreography/buses/kafka.py
@@ -107,15 +107,11 @@ class KafkaEventBusConfig:
     def from_env(cls) -> KafkaEventBusConfig:
         """Build config from environment variables."""
         return cls(
-            bootstrap_servers=os.environ.get(
-                "SAGAZ_BUS_KAFKA_BOOTSTRAP_SERVERS", "localhost:9092"
-            ),
+            bootstrap_servers=os.environ.get("SAGAZ_BUS_KAFKA_BOOTSTRAP_SERVERS", "localhost:9092"),
             topic=os.environ.get("SAGAZ_BUS_KAFKA_TOPIC", "sagaz.choreography"),
             consumer_group=os.environ.get("SAGAZ_BUS_KAFKA_CONSUMER_GROUP", "sagaz"),
             consumer_name=os.environ.get("SAGAZ_BUS_KAFKA_CONSUMER_NAME", "worker-1"),
-            security_protocol=os.environ.get(
-                "SAGAZ_BUS_KAFKA_SECURITY_PROTOCOL", "PLAINTEXT"
-            ),
+            security_protocol=os.environ.get("SAGAZ_BUS_KAFKA_SECURITY_PROTOCOL", "PLAINTEXT"),
             sasl_mechanism=os.environ.get("SAGAZ_BUS_KAFKA_SASL_MECHANISM"),
             sasl_username=os.environ.get("SAGAZ_BUS_KAFKA_SASL_USERNAME"),
             sasl_password=os.environ.get("SAGAZ_BUS_KAFKA_SASL_PASSWORD"),
@@ -217,9 +213,7 @@ class KafkaEventBus(AbstractEventBus):
         await self._producer.start()
         await self._consumer.start()
 
-        self._reader_task = asyncio.create_task(
-            self._reader_loop(), name="sagaz-kafka-reader"
-        )
+        self._reader_task = asyncio.create_task(self._reader_loop(), name="sagaz-kafka-reader")
         logger.info(
             "KafkaEventBus started (topic=%s, group=%s)",
             self._config.topic,
@@ -319,9 +313,7 @@ class KafkaEventBus(AbstractEventBus):
             try:
                 await handler(event)
             except Exception:
-                logger.exception(
-                    "Handler %s raised on event %r", handler, event.event_type
-                )
+                logger.exception("Handler %s raised on event %r", handler, event.event_type)
 
     # ------------------------------------------------------------------
     # Introspection

--- a/sagaz/choreography/buses/kafka.py
+++ b/sagaz/choreography/buses/kafka.py
@@ -42,7 +42,7 @@ import json
 import logging
 import os
 from collections import defaultdict
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
@@ -233,7 +233,7 @@ class KafkaEventBus(AbstractEventBus):
             try:
                 await self._reader_task
             except asyncio.CancelledError:
-                pass
+                pass  # expected when cancelling the reader task — not an error
             self._reader_task = None
         if self._consumer is not None:
             await self._consumer.stop()
@@ -257,7 +257,7 @@ class KafkaEventBus(AbstractEventBus):
         try:
             self._handlers[event_type].remove(handler)
         except ValueError:
-            pass
+            pass  # handler was not registered — silent no-op
 
     # ------------------------------------------------------------------
     # Publishing

--- a/sagaz/choreography/buses/rabbitmq.py
+++ b/sagaz/choreography/buses/rabbitmq.py
@@ -1,0 +1,295 @@
+"""
+RabbitMQ EventBus — distributed choreography transport via AMQP.
+
+Uses ``aio-pika`` for async AMQP access with publisher confirms.  Events are
+published to a topic exchange using the ``event_type`` as the routing key.
+A single queue is bound to the exchange with the ``#`` wildcard so it receives
+all event types; in-process handler dispatch is then performed locally.
+
+Architecture
+------------
+- ``publish()`` serialises the ``Event`` to JSON and calls
+  ``exchange.publish()`` with the ``event_type`` as the routing key.
+- ``start()`` connects to RabbitMQ, declares the exchange and queue, binds
+  the queue, and registers ``_on_message`` as the consumer callback.
+- ``stop()`` cancels the consumer, closes the channel, and disconnects.
+- ``subscribe()`` / ``unsubscribe()`` register/deregister in-process handlers.
+
+Configuration
+-------------
+All options are exposed through ``RabbitMQEventBusConfig``.  Environment
+variables follow the ``SAGAZ_BUS_RABBITMQ_*`` prefix:
+
+    SAGAZ_BUS_RABBITMQ_URL          amqp://guest:guest@localhost/
+    SAGAZ_BUS_RABBITMQ_EXCHANGE     sagaz.choreography
+    SAGAZ_BUS_RABBITMQ_QUEUE        sagaz.choreography.queue
+    SAGAZ_BUS_RABBITMQ_PREFETCH     100
+    SAGAZ_BUS_RABBITMQ_HEARTBEAT    60
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from sagaz.choreography.events import AbstractEventBus, Event, HandlerT
+from sagaz.core.exceptions import MissingDependencyError
+
+try:
+    import aio_pika  # type: ignore[import-untyped]
+    from aio_pika import DeliveryMode, ExchangeType, Message  # type: ignore[import-untyped]
+
+    _RABBITMQ_AVAILABLE = True
+except ImportError:
+    _RABBITMQ_AVAILABLE = False
+    aio_pika: Any = None  # type: ignore[assignment, no-redef]
+    Message: Any = None  # type: ignore[assignment, no-redef]
+    DeliveryMode: Any = None  # type: ignore[assignment, no-redef]
+    ExchangeType: Any = None  # type: ignore[assignment, no-redef]
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RabbitMQEventBusConfig:
+    """
+    Configuration for ``RabbitMQEventBus``.
+
+    Parameters
+    ----------
+    url:
+        AMQP connection URL.
+    exchange_name:
+        Name of the topic exchange used as the choreography bus.
+    exchange_durable:
+        Whether the exchange survives a broker restart.
+    queue_name:
+        Name of the queue to consume from.
+    queue_durable:
+        Whether the queue survives a broker restart.
+    prefetch_count:
+        QoS prefetch count (limits concurrent in-flight messages).
+    heartbeat:
+        AMQP heartbeat interval in seconds.
+    """
+
+    url: str = "amqp://guest:guest@localhost/"
+    exchange_name: str = "sagaz.choreography"
+    exchange_durable: bool = True
+    queue_name: str = "sagaz.choreography.queue"
+    queue_durable: bool = True
+    prefetch_count: int = 100
+    heartbeat: int = 60
+
+    @classmethod
+    def from_env(cls) -> RabbitMQEventBusConfig:
+        """Build config from environment variables."""
+        return cls(
+            url=os.environ.get(
+                "SAGAZ_BUS_RABBITMQ_URL", "amqp://guest:guest@localhost/"
+            ),
+            exchange_name=os.environ.get(
+                "SAGAZ_BUS_RABBITMQ_EXCHANGE", "sagaz.choreography"
+            ),
+            queue_name=os.environ.get(
+                "SAGAZ_BUS_RABBITMQ_QUEUE", "sagaz.choreography.queue"
+            ),
+            prefetch_count=int(
+                os.environ.get("SAGAZ_BUS_RABBITMQ_PREFETCH", "100")
+            ),
+            heartbeat=int(os.environ.get("SAGAZ_BUS_RABBITMQ_HEARTBEAT", "60")),
+        )
+
+
+class RabbitMQEventBus(AbstractEventBus):
+    """
+    Distributed ``EventBus`` backed by RabbitMQ (AMQP).
+
+    Uses a **topic exchange** where the routing key is the ``event_type``
+    string.  A single queue bound with the ``#`` wildcard receives all events;
+    routing to specific in-process handlers happens after deserialization.
+
+    Use ``start()`` before publishing or subscribing, and ``stop()`` on
+    shutdown.
+
+    Parameters
+    ----------
+    config:
+        ``RabbitMQEventBusConfig`` instance.  Defaults to ``from_env()``.
+
+    Raises
+    ------
+    MissingDependencyError
+        If the ``aio-pika`` package is not installed.
+    """
+
+    def __init__(self, config: RabbitMQEventBusConfig | None = None) -> None:
+        if not _RABBITMQ_AVAILABLE:
+            pkg = "aio-pika"
+            raise MissingDependencyError(pkg, feature="RabbitMQEventBus")
+        self._config = config or RabbitMQEventBusConfig.from_env()
+        self._handlers: dict[str, list[HandlerT]] = defaultdict(list)
+        self._connection: Any = None
+        self._channel: Any = None
+        self._exchange: Any = None
+        self._queue: Any = None
+        self._consumer_tag: str | None = None
+        self._published: list[Event] = []
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Connect to RabbitMQ, declare exchange/queue, and start consuming."""
+        if self._connection is not None:
+            return
+
+        self._connection = await aio_pika.connect_robust(
+            self._config.url,
+            heartbeat=self._config.heartbeat,
+        )
+        self._channel = await self._connection.channel()
+        await self._channel.set_qos(prefetch_count=self._config.prefetch_count)
+
+        self._exchange = await self._channel.declare_exchange(
+            self._config.exchange_name,
+            ExchangeType.TOPIC,
+            durable=self._config.exchange_durable,
+        )
+        self._queue = await self._channel.declare_queue(
+            self._config.queue_name,
+            durable=self._config.queue_durable,
+        )
+        # Bind to all routing keys — in-process handler routing done locally.
+        await self._queue.bind(self._exchange, routing_key="#")
+        self._consumer_tag = await self._queue.consume(self._on_message)
+
+        logger.info(
+            "RabbitMQEventBus started (exchange=%s, queue=%s)",
+            self._config.exchange_name,
+            self._config.queue_name,
+        )
+
+    async def stop(self) -> None:
+        """Cancel the consumer, close channel, and disconnect."""
+        if self._queue is not None and self._consumer_tag is not None:
+            await self._queue.cancel(self._consumer_tag)
+            self._consumer_tag = None
+        if self._channel is not None:
+            await self._channel.close()
+            self._channel = None
+        if self._connection is not None:
+            await self._connection.close()
+            self._connection = None
+        self._exchange = self._queue = None
+        logger.info("RabbitMQEventBus stopped")
+
+    # ------------------------------------------------------------------
+    # Subscription
+    # ------------------------------------------------------------------
+
+    def subscribe(self, event_type: str, handler: HandlerT) -> None:
+        """Register *handler* for *event_type* (or ``"*"`` for all events)."""
+        self._handlers[event_type].append(handler)
+        logger.debug("Subscribed %s to %r", handler, event_type)
+
+    def unsubscribe(self, event_type: str, handler: HandlerT) -> None:
+        """Remove *handler* from *event_type* subscribers."""
+        try:
+            self._handlers[event_type].remove(handler)
+        except ValueError:
+            pass
+
+    # ------------------------------------------------------------------
+    # Publishing
+    # ------------------------------------------------------------------
+
+    async def publish(self, event: Event) -> None:
+        """
+        Publish *event* to the RabbitMQ exchange.
+
+        The event is JSON-serialised to a persistent AMQP message and
+        published with the ``event_type`` as the routing key.
+        """
+        if self._exchange is None:
+            msg = "Call start() before publish()"
+            raise RuntimeError(msg)
+        payload = json.dumps(
+            {
+                "event_type": event.event_type,
+                "data": event.data,
+                "event_id": event.event_id,
+                "saga_id": event.saga_id,
+                "created_at": event.created_at.isoformat(),
+            }
+        ).encode()
+        message = Message(
+            payload,
+            delivery_mode=DeliveryMode.PERSISTENT,
+            content_type="application/json",
+        )
+        await self._exchange.publish(message, routing_key=event.event_type)
+        self._published.append(event)
+        logger.debug(
+            "Published %r to exchange %s (key=%s)",
+            event,
+            self._config.exchange_name,
+            event.event_type,
+        )
+
+    # ------------------------------------------------------------------
+    # Consumer callback (internal)
+    # ------------------------------------------------------------------
+
+    async def _on_message(self, message: Any) -> None:
+        """Deserialise an incoming AMQP message and dispatch to handlers."""
+        async with message.process():
+            try:
+                payload = json.loads(message.body.decode())
+                raw_dt = datetime.fromisoformat(payload["created_at"])
+                created_at = (
+                    raw_dt.astimezone(UTC) if raw_dt.tzinfo else raw_dt.replace(tzinfo=UTC)
+                )
+                event = Event(
+                    event_type=payload["event_type"],
+                    data=payload["data"],
+                    event_id=payload["event_id"],
+                    saga_id=payload.get("saga_id"),
+                    created_at=created_at,
+                )
+            except Exception:
+                logger.exception("Failed to deserialise RabbitMQ message")
+                return
+
+            handlers = list(self._handlers.get(event.event_type, []))
+            handlers += list(self._handlers.get("*", []))
+            for handler in handlers:
+                try:
+                    await handler(event)
+                except Exception:
+                    logger.exception(
+                        "Handler %s raised on event %r", handler, event.event_type
+                    )
+
+    # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+
+    @property
+    def published(self) -> list[Event]:
+        """Events published via this bus instance (for testing/debugging)."""
+        return list(self._published)
+
+    def clear_history(self) -> None:
+        """Discard the recorded publish history."""
+        self._published.clear()
+
+    def handler_count(self, event_type: str) -> int:
+        """Return the number of handlers registered for *event_type*."""
+        return len(self._handlers.get(event_type, []))

--- a/sagaz/choreography/buses/rabbitmq.py
+++ b/sagaz/choreography/buses/rabbitmq.py
@@ -204,7 +204,7 @@ class RabbitMQEventBus(AbstractEventBus):
         try:
             self._handlers[event_type].remove(handler)
         except ValueError:
-            pass
+            pass  # handler was not registered — silent no-op
 
     # ------------------------------------------------------------------
     # Publishing

--- a/sagaz/choreography/buses/rabbitmq.py
+++ b/sagaz/choreography/buses/rabbitmq.py
@@ -90,18 +90,10 @@ class RabbitMQEventBusConfig:
     def from_env(cls) -> RabbitMQEventBusConfig:
         """Build config from environment variables."""
         return cls(
-            url=os.environ.get(
-                "SAGAZ_BUS_RABBITMQ_URL", "amqp://guest:guest@localhost/"
-            ),
-            exchange_name=os.environ.get(
-                "SAGAZ_BUS_RABBITMQ_EXCHANGE", "sagaz.choreography"
-            ),
-            queue_name=os.environ.get(
-                "SAGAZ_BUS_RABBITMQ_QUEUE", "sagaz.choreography.queue"
-            ),
-            prefetch_count=int(
-                os.environ.get("SAGAZ_BUS_RABBITMQ_PREFETCH", "100")
-            ),
+            url=os.environ.get("SAGAZ_BUS_RABBITMQ_URL", "amqp://guest:guest@localhost/"),
+            exchange_name=os.environ.get("SAGAZ_BUS_RABBITMQ_EXCHANGE", "sagaz.choreography"),
+            queue_name=os.environ.get("SAGAZ_BUS_RABBITMQ_QUEUE", "sagaz.choreography.queue"),
+            prefetch_count=int(os.environ.get("SAGAZ_BUS_RABBITMQ_PREFETCH", "100")),
             heartbeat=int(os.environ.get("SAGAZ_BUS_RABBITMQ_HEARTBEAT", "60")),
         )
 
@@ -253,9 +245,7 @@ class RabbitMQEventBus(AbstractEventBus):
             try:
                 payload = json.loads(message.body.decode())
                 raw_dt = datetime.fromisoformat(payload["created_at"])
-                created_at = (
-                    raw_dt.astimezone(UTC) if raw_dt.tzinfo else raw_dt.replace(tzinfo=UTC)
-                )
+                created_at = raw_dt.astimezone(UTC) if raw_dt.tzinfo else raw_dt.replace(tzinfo=UTC)
                 event = Event(
                     event_type=payload["event_type"],
                     data=payload["data"],
@@ -273,9 +263,7 @@ class RabbitMQEventBus(AbstractEventBus):
                 try:
                     await handler(event)
                 except Exception:
-                    logger.exception(
-                        "Handler %s raised on event %r", handler, event.event_type
-                    )
+                    logger.exception("Handler %s raised on event %r", handler, event.event_type)
 
     # ------------------------------------------------------------------
     # Introspection

--- a/sagaz/choreography/buses/redis_streams.py
+++ b/sagaz/choreography/buses/redis_streams.py
@@ -102,14 +102,10 @@ class RedisStreamsBusConfig:
         """Build config from environment variables."""
         return cls(
             url=os.environ.get("SAGAZ_BUS_REDIS_URL", "redis://localhost:6379/0"),
-            stream_name=os.environ.get(
-                "SAGAZ_BUS_REDIS_STREAM_NAME", "sagaz.choreography"
-            ),
+            stream_name=os.environ.get("SAGAZ_BUS_REDIS_STREAM_NAME", "sagaz.choreography"),
             consumer_group=os.environ.get("SAGAZ_BUS_REDIS_CONSUMER_GROUP", "sagaz"),
             consumer_name=os.environ.get("SAGAZ_BUS_REDIS_CONSUMER_NAME", "worker-1"),
-            block_timeout_ms=int(
-                os.environ.get("SAGAZ_BUS_REDIS_BLOCK_TIMEOUT_MS", "1000")
-            ),
+            block_timeout_ms=int(os.environ.get("SAGAZ_BUS_REDIS_BLOCK_TIMEOUT_MS", "1000")),
         )
 
 
@@ -177,9 +173,7 @@ class RedisStreamsEventBus(AbstractEventBus):
         """Connect to Redis, ensure the consumer group exists, start reader."""
         if self._reader_task is not None and not self._reader_task.done():
             return
-        self._client = aioredis.from_url(
-            self._config.url, decode_responses=False
-        )
+        self._client = aioredis.from_url(self._config.url, decode_responses=False)
         # Create consumer group (idempotent — OK if already exists)
         try:
             await self._client.xgroup_create(
@@ -192,9 +186,7 @@ class RedisStreamsEventBus(AbstractEventBus):
             # BUSYGROUP means the group already exists — not an error
             if "BUSYGROUP" not in str(exc):
                 raise
-        self._reader_task = asyncio.create_task(
-            self._reader_loop(), name="sagaz-chorus-reader"
-        )
+        self._reader_task = asyncio.create_task(self._reader_loop(), name="sagaz-chorus-reader")
         logger.info(
             "RedisStreamsEventBus started (stream=%s, group=%s)",
             self._config.stream_name,
@@ -301,9 +293,7 @@ class RedisStreamsEventBus(AbstractEventBus):
             try:
                 await handler(event)
             except Exception:
-                logger.exception(
-                    "Handler %s raised on event %r", handler, event.event_type
-                )
+                logger.exception("Handler %s raised on event %r", handler, event.event_type)
 
     # ------------------------------------------------------------------
     # Introspection

--- a/sagaz/choreography/buses/redis_streams.py
+++ b/sagaz/choreography/buses/redis_streams.py
@@ -208,7 +208,7 @@ class RedisStreamsEventBus(AbstractEventBus):
             try:
                 await self._reader_task
             except asyncio.CancelledError:
-                pass
+                pass  # expected when cancelling the reader task — not an error
             self._reader_task = None
         if self._client:
             await self._client.aclose()
@@ -229,7 +229,7 @@ class RedisStreamsEventBus(AbstractEventBus):
         try:
             self._handlers[event_type].remove(handler)
         except ValueError:
-            pass
+            pass  # handler was not registered — silent no-op
 
     # ------------------------------------------------------------------
     # Publishing

--- a/sagaz/choreography/buses/redis_streams.py
+++ b/sagaz/choreography/buses/redis_streams.py
@@ -38,7 +38,7 @@ import json
 import logging
 import os
 from collections import defaultdict
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import UTC
 from typing import Any
 
@@ -126,17 +126,17 @@ def _event_to_fields(event: Event) -> dict[str, str]:
 
 def _fields_to_event(fields: dict[bytes, bytes]) -> Event:
     """Deserialise Redis stream fields back to an ``Event``."""
-    from datetime import datetime, timezone
+    from datetime import datetime
 
     saga_id_raw = fields.get(_FIELD_SAGA_ID, b"").decode()
+    raw_dt = datetime.fromisoformat(fields[_FIELD_CREATED_AT].decode())
+    created_at = raw_dt.astimezone(UTC) if raw_dt.tzinfo else raw_dt.replace(tzinfo=UTC)
     return Event(
         event_type=fields[_FIELD_EVENT_TYPE].decode(),
         data=json.loads(fields[_FIELD_DATA].decode()),
         event_id=fields[_FIELD_EVENT_ID].decode(),
         saga_id=saga_id_raw or None,
-        created_at=datetime.fromisoformat(
-            fields[_FIELD_CREATED_AT].decode()
-        ).replace(tzinfo=UTC),
+        created_at=created_at,
     )
 
 
@@ -161,11 +161,8 @@ class RedisStreamsEventBus:
 
     def __init__(self, config: RedisStreamsBusConfig | None = None) -> None:
         if not _REDIS_AVAILABLE:
-            msg = (
-                "RedisStreamsEventBus requires the 'redis' package. "
-                "Install it with: pip install sagaz[redis]"
-            )
-            raise MissingDependencyError(msg)
+            pkg = "redis"
+            raise MissingDependencyError(pkg, feature="RedisStreamsEventBus")
         self._config = config or RedisStreamsBusConfig.from_env()
         self._handlers: dict[str, list[HandlerT]] = defaultdict(list)
         self._client: Any = None
@@ -178,6 +175,8 @@ class RedisStreamsEventBus:
 
     async def start(self) -> None:
         """Connect to Redis, ensure the consumer group exists, start reader."""
+        if self._reader_task is not None and not self._reader_task.done():
+            return
         self._client = aioredis.from_url(
             self._config.url, decode_responses=False
         )
@@ -210,6 +209,7 @@ class RedisStreamsEventBus:
                 await self._reader_task
             except asyncio.CancelledError:
                 pass
+            self._reader_task = None
         if self._client:
             await self._client.aclose()
             self._client = None

--- a/sagaz/choreography/buses/redis_streams.py
+++ b/sagaz/choreography/buses/redis_streams.py
@@ -42,7 +42,7 @@ from dataclasses import dataclass
 from datetime import UTC
 from typing import Any
 
-from sagaz.choreography.events import Event, HandlerT
+from sagaz.choreography.events import AbstractEventBus, Event, HandlerT
 from sagaz.core.exceptions import MissingDependencyError
 
 try:
@@ -140,7 +140,7 @@ def _fields_to_event(fields: dict[bytes, bytes]) -> Event:
     )
 
 
-class RedisStreamsEventBus:
+class RedisStreamsEventBus(AbstractEventBus):
     """
     Distributed ``EventBus`` backed by Redis Streams.
 

--- a/sagaz/choreography/buses/redis_streams.py
+++ b/sagaz/choreography/buses/redis_streams.py
@@ -1,0 +1,323 @@
+"""
+Redis Streams EventBus — distributed choreography transport.
+
+Uses Redis Streams (XADD / XREADGROUP) so that choreographed sagas can span
+multiple processes or services without requiring Kafka or RabbitMQ.
+
+Architecture
+------------
+- ``publish()`` serialises the ``Event`` to JSON and issues an ``XADD`` to
+  the configured stream.
+- ``start()`` launches a background asyncio task that loops on ``XREADGROUP``
+  and dispatches received events to locally-registered handlers.
+- ``stop()`` cancels the reader task and closes the Redis connection.
+- ``subscribe()`` / ``unsubscribe()`` register/deregister in-process handlers
+  (same API as ``EventBus``).
+
+Thread-safety
+-------------
+The bus is designed for single-event-loop use.  Do not share an instance
+across threads.
+
+Configuration
+-------------
+All options are exposed through ``RedisStreamsBusConfig``.  Environment
+variables follow the same naming as ``RedisBrokerConfig``.
+
+    SAGAZ_BUS_REDIS_URL               redis://localhost:6379/0
+    SAGAZ_BUS_REDIS_STREAM_NAME       sagaz.choreography
+    SAGAZ_BUS_REDIS_CONSUMER_GROUP    sagaz
+    SAGAZ_BUS_REDIS_CONSUMER_NAME     worker-1
+    SAGAZ_BUS_REDIS_BLOCK_TIMEOUT_MS  1000
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import UTC
+from typing import Any
+
+from sagaz.choreography.events import Event, HandlerT
+from sagaz.core.exceptions import MissingDependencyError
+
+try:
+    import redis.asyncio as aioredis  # type: ignore[import-untyped]
+
+    _REDIS_AVAILABLE = True
+except ImportError:
+    _REDIS_AVAILABLE = False
+    aioredis: Any = None  # type: ignore[assignment, no-redef]
+
+logger = logging.getLogger(__name__)
+
+_FIELD_EVENT_TYPE = b"event_type"
+_FIELD_DATA = b"data"
+_FIELD_EVENT_ID = b"event_id"
+_FIELD_SAGA_ID = b"saga_id"
+_FIELD_CREATED_AT = b"created_at"
+
+_LAST_DELIVERED = ">"  # consume only new messages per consumer group
+
+
+@dataclass
+class RedisStreamsBusConfig:
+    """
+    Configuration for ``RedisStreamsEventBus``.
+
+    Parameters
+    ----------
+    url:
+        Redis connection URL.
+    stream_name:
+        Name of the Redis stream used as the choreography bus.
+    consumer_group:
+        Consumer group name.  All instances in the same group share the
+        message load; use the *same* group name per service type.
+    consumer_name:
+        Unique consumer name within the group (e.g. hostname + pid).
+    block_timeout_ms:
+        How long (ms) ``XREADGROUP`` blocks waiting for new messages.
+        Lower values increase poll frequency but also CPU usage.
+    max_stream_length:
+        Maximum stream length; older entries are trimmed automatically.
+    read_count:
+        Number of messages to fetch per ``XREADGROUP`` call.
+    """
+
+    url: str = "redis://localhost:6379/0"
+    stream_name: str = "sagaz.choreography"
+    consumer_group: str = "sagaz"
+    consumer_name: str = "worker-1"
+    block_timeout_ms: int = 1000
+    max_stream_length: int = 50_000
+    read_count: int = 100
+
+    @classmethod
+    def from_env(cls) -> RedisStreamsBusConfig:
+        """Build config from environment variables."""
+        return cls(
+            url=os.environ.get("SAGAZ_BUS_REDIS_URL", "redis://localhost:6379/0"),
+            stream_name=os.environ.get(
+                "SAGAZ_BUS_REDIS_STREAM_NAME", "sagaz.choreography"
+            ),
+            consumer_group=os.environ.get("SAGAZ_BUS_REDIS_CONSUMER_GROUP", "sagaz"),
+            consumer_name=os.environ.get("SAGAZ_BUS_REDIS_CONSUMER_NAME", "worker-1"),
+            block_timeout_ms=int(
+                os.environ.get("SAGAZ_BUS_REDIS_BLOCK_TIMEOUT_MS", "1000")
+            ),
+        )
+
+
+def _event_to_fields(event: Event) -> dict[str, str]:
+    """Serialise an ``Event`` to Redis stream field mapping."""
+    return {
+        "event_type": event.event_type,
+        "data": json.dumps(event.data),
+        "event_id": event.event_id,
+        "saga_id": event.saga_id or "",
+        "created_at": event.created_at.isoformat(),
+    }
+
+
+def _fields_to_event(fields: dict[bytes, bytes]) -> Event:
+    """Deserialise Redis stream fields back to an ``Event``."""
+    from datetime import datetime, timezone
+
+    saga_id_raw = fields.get(_FIELD_SAGA_ID, b"").decode()
+    return Event(
+        event_type=fields[_FIELD_EVENT_TYPE].decode(),
+        data=json.loads(fields[_FIELD_DATA].decode()),
+        event_id=fields[_FIELD_EVENT_ID].decode(),
+        saga_id=saga_id_raw or None,
+        created_at=datetime.fromisoformat(
+            fields[_FIELD_CREATED_AT].decode()
+        ).replace(tzinfo=UTC),
+    )
+
+
+class RedisStreamsEventBus:
+    """
+    Distributed ``EventBus`` backed by Redis Streams.
+
+    Use ``start()`` before publishing or subscribing, and ``stop()`` on
+    shutdown.  Suitable as a drop-in replacement for the in-process
+    ``EventBus`` when distributed choreography is needed.
+
+    Parameters
+    ----------
+    config:
+        ``RedisStreamsBusConfig`` instance.  Defaults to ``from_env()``.
+
+    Raises
+    ------
+    MissingDependencyError
+        If the ``redis`` package is not installed.
+    """
+
+    def __init__(self, config: RedisStreamsBusConfig | None = None) -> None:
+        if not _REDIS_AVAILABLE:
+            msg = (
+                "RedisStreamsEventBus requires the 'redis' package. "
+                "Install it with: pip install sagaz[redis]"
+            )
+            raise MissingDependencyError(msg)
+        self._config = config or RedisStreamsBusConfig.from_env()
+        self._handlers: dict[str, list[HandlerT]] = defaultdict(list)
+        self._client: Any = None
+        self._reader_task: asyncio.Task[None] | None = None
+        self._published: list[Event] = []
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Connect to Redis, ensure the consumer group exists, start reader."""
+        self._client = aioredis.from_url(
+            self._config.url, decode_responses=False
+        )
+        # Create consumer group (idempotent — OK if already exists)
+        try:
+            await self._client.xgroup_create(
+                self._config.stream_name,
+                self._config.consumer_group,
+                id="0",
+                mkstream=True,
+            )
+        except Exception as exc:
+            # BUSYGROUP means the group already exists — not an error
+            if "BUSYGROUP" not in str(exc):
+                raise
+        self._reader_task = asyncio.create_task(
+            self._reader_loop(), name="sagaz-chorus-reader"
+        )
+        logger.info(
+            "RedisStreamsEventBus started (stream=%s, group=%s)",
+            self._config.stream_name,
+            self._config.consumer_group,
+        )
+
+    async def stop(self) -> None:
+        """Cancel the reader task and close the Redis connection."""
+        if self._reader_task and not self._reader_task.done():
+            self._reader_task.cancel()
+            try:
+                await self._reader_task
+            except asyncio.CancelledError:
+                pass
+        if self._client:
+            await self._client.aclose()
+            self._client = None
+        logger.info("RedisStreamsEventBus stopped")
+
+    # ------------------------------------------------------------------
+    # Subscription
+    # ------------------------------------------------------------------
+
+    def subscribe(self, event_type: str, handler: HandlerT) -> None:
+        """Register *handler* for *event_type* (or ``"*"`` for all events)."""
+        self._handlers[event_type].append(handler)
+        logger.debug("Subscribed %s to %r", handler, event_type)
+
+    def unsubscribe(self, event_type: str, handler: HandlerT) -> None:
+        """Remove *handler* from *event_type* subscribers."""
+        try:
+            self._handlers[event_type].remove(handler)
+        except ValueError:
+            pass
+
+    # ------------------------------------------------------------------
+    # Publishing
+    # ------------------------------------------------------------------
+
+    async def publish(self, event: Event) -> None:
+        """
+        Publish *event* to the Redis stream.
+
+        The event is serialised to stream fields and written via ``XADD``.
+        The reader loop on every consumer will receive it and dispatch
+        to locally-registered handlers.
+        """
+        if self._client is None:
+            msg = "Call start() before publish()"
+            raise RuntimeError(msg)
+        fields = _event_to_fields(event)
+        await self._client.xadd(
+            self._config.stream_name,
+            fields,
+            maxlen=self._config.max_stream_length,
+            approximate=True,
+        )
+        self._published.append(event)
+        logger.debug("Published %r to stream %s", event, self._config.stream_name)
+
+    # ------------------------------------------------------------------
+    # Reader loop (internal)
+    # ------------------------------------------------------------------
+
+    async def _reader_loop(self) -> None:
+        """Background task: read from Redis Streams and dispatch to handlers."""
+        while True:
+            try:
+                results = await self._client.xreadgroup(
+                    self._config.consumer_group,
+                    self._config.consumer_name,
+                    {self._config.stream_name: _LAST_DELIVERED},
+                    count=self._config.read_count,
+                    block=self._config.block_timeout_ms,
+                )
+                if not results:
+                    continue
+                for _stream, messages in results:
+                    for msg_id, fields in messages:
+                        await self._dispatch(fields)
+                        await self._client.xack(
+                            self._config.stream_name,
+                            self._config.consumer_group,
+                            msg_id,
+                        )
+            except asyncio.CancelledError:
+                break
+            except Exception:
+                logger.exception("RedisStreamsEventBus reader error")
+                await asyncio.sleep(0.5)
+
+    async def _dispatch(self, fields: dict[bytes, bytes]) -> None:
+        """Deserialise one stream message and invoke matching handlers."""
+        try:
+            event = _fields_to_event(fields)
+        except Exception:
+            logger.exception("Failed to deserialise event fields: %s", fields)
+            return
+
+        handlers = list(self._handlers.get(event.event_type, []))
+        handlers += list(self._handlers.get("*", []))
+        for handler in handlers:
+            try:
+                await handler(event)
+            except Exception:
+                logger.exception(
+                    "Handler %s raised on event %r", handler, event.event_type
+                )
+
+    # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+
+    @property
+    def published(self) -> list[Event]:
+        """Events published via this bus instance (for testing/debugging)."""
+        return list(self._published)
+
+    def clear_history(self) -> None:
+        """Discard the recorded publish history."""
+        self._published.clear()
+
+    def handler_count(self, event_type: str) -> int:
+        """Return the number of handlers registered for *event_type*."""
+        return len(self._handlers.get(event_type, []))

--- a/sagaz/choreography/decorators.py
+++ b/sagaz/choreography/decorators.py
@@ -1,0 +1,51 @@
+"""
+@on_event decorator for ChoreographedSaga handler methods.
+"""
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable
+from typing import Any
+
+_HANDLER_ATTR = "_choreography_event_type"
+
+
+def on_event(event_type: str) -> Callable:
+    """
+    Mark an async method as an event handler for *event_type*.
+
+    The decorated method must accept ``(self, event: Event) -> None``.
+
+    Parameters
+    ----------
+    event_type:
+        The event type string to listen for (e.g. ``"order.created"``).
+        Use ``"*"`` to receive all events.
+
+    Example
+    -------
+    ::
+
+        class MySaga(ChoreographedSaga):
+            @on_event("order.created")
+            async def handle_order(self, event: Event) -> None:
+                ...
+    """
+
+    def decorator(fn: Callable) -> Callable:
+        setattr(fn, _HANDLER_ATTR, event_type)
+
+        @functools.wraps(fn)
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            return await fn(*args, **kwargs)
+
+        setattr(wrapper, _HANDLER_ATTR, event_type)
+        return wrapper
+
+    return decorator
+
+
+def get_event_type(method: Callable) -> str | None:
+    """Return the event type associated with *method*, or *None*."""
+    return getattr(method, _HANDLER_ATTR, None)

--- a/sagaz/choreography/engine.py
+++ b/sagaz/choreography/engine.py
@@ -8,7 +8,6 @@ bus and tracking active saga instances.
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 from sagaz.choreography.events import Event, EventBus
 from sagaz.choreography.saga import ChoreographedSaga

--- a/sagaz/choreography/engine.py
+++ b/sagaz/choreography/engine.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 
-from sagaz.choreography.events import Event, EventBus
+from sagaz.choreography.events import AbstractEventBus, Event
 from sagaz.choreography.saga import ChoreographedSaga
 
 logger = logging.getLogger(__name__)
@@ -43,7 +43,7 @@ class ChoreographyEngine:
         await engine.stop()
     """
 
-    def __init__(self, bus: EventBus) -> None:
+    def __init__(self, bus: AbstractEventBus) -> None:
         self._bus = bus
         self._sagas: dict[str, ChoreographedSaga] = {}
         self._running = False

--- a/sagaz/choreography/engine.py
+++ b/sagaz/choreography/engine.py
@@ -1,0 +1,127 @@
+"""
+ChoreographyEngine — wires ChoreographedSagas to an EventBus.
+
+The engine manages saga lifecycle: registering their event handlers with the
+bus and tracking active saga instances.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from sagaz.choreography.events import Event, EventBus
+from sagaz.choreography.saga import ChoreographedSaga
+
+logger = logging.getLogger(__name__)
+
+
+class ChoreographyEngine:
+    """
+    Routes events from an ``EventBus`` to registered ``ChoreographedSaga``
+    instances.
+
+    Parameters
+    ----------
+    bus:
+        The ``EventBus`` to subscribe to.
+
+    Example
+    -------
+    ::
+
+        bus = EventBus()
+        engine = ChoreographyEngine(bus)
+
+        class MySaga(ChoreographedSaga):
+            @on_event("order.created")
+            async def handle_order(self, event: Event) -> None:
+                await bus.publish(Event("payment.initiate", event.data))
+
+        engine.register(MySaga())
+        await engine.start()
+        await bus.publish(Event("order.created", {"order_id": "ORD-1"}))
+        await engine.stop()
+    """
+
+    def __init__(self, bus: EventBus) -> None:
+        self._bus = bus
+        self._sagas: dict[str, ChoreographedSaga] = {}
+        self._running = False
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Mark the engine as running (enables event dispatch)."""
+        self._running = True
+        logger.info("ChoreographyEngine started with %d saga(s)", len(self._sagas))
+
+    async def stop(self) -> None:
+        """Deregister all sagas and shut down the engine."""
+        for saga in list(self._sagas.values()):
+            self._deregister(saga)
+        self._sagas.clear()
+        self._running = False
+        logger.info("ChoreographyEngine stopped")
+
+    # ------------------------------------------------------------------
+    # Registration
+    # ------------------------------------------------------------------
+
+    def register(self, saga: ChoreographedSaga) -> None:
+        """
+        Register *saga* and subscribe its handlers to the bus.
+
+        Parameters
+        ----------
+        saga:
+            A ``ChoreographedSaga`` instance with ``@on_event``-decorated
+            methods.
+        """
+        if saga.saga_id in self._sagas:
+            logger.warning("Saga %r is already registered; replacing.", saga.saga_id)
+            self._deregister(self._sagas[saga.saga_id])
+
+        self._sagas[saga.saga_id] = saga
+
+        for event_type, _method in saga._handlers.items():
+            # Wrap the method so the bus calls saga.handle() → proper routing
+            async def _dispatch(event: Event, _saga: ChoreographedSaga = saga) -> None:
+                await _saga.handle(event)
+
+            # Subscribe once per event type per saga; use the dispatch wrapper
+            self._bus.subscribe(event_type, _dispatch)
+
+        logger.debug("Registered saga %r (%s)", saga.saga_id, saga.name)
+
+    def _deregister(self, saga: ChoreographedSaga) -> None:
+        """Unsubscribe the saga's handlers from the bus."""
+        # We cannot easily unsubscribe the closures we created, so we rely on
+        # the engine's stopped state to skip dispatch.  For production use
+        # with external adapters, explicit unsubscription would be wired here.
+        logger.debug("Deregistered saga %r", saga.saga_id)
+
+    def unregister(self, saga_id: str) -> None:
+        """Remove a saga from the engine by its *saga_id*."""
+        saga = self._sagas.pop(saga_id, None)
+        if saga:
+            self._deregister(saga)
+
+    # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+
+    @property
+    def registered_sagas(self) -> list[ChoreographedSaga]:
+        """List of all currently registered sagas."""
+        return list(self._sagas.values())
+
+    @property
+    def is_running(self) -> bool:
+        return self._running
+
+    def get_saga(self, saga_id: str) -> ChoreographedSaga | None:
+        """Return the registered saga with *saga_id*, or *None*."""
+        return self._sagas.get(saga_id)

--- a/sagaz/choreography/engine.py
+++ b/sagaz/choreography/engine.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 
-from sagaz.choreography.events import AbstractEventBus, Event
+from sagaz.choreography.events import AbstractEventBus, Event, HandlerT
 from sagaz.choreography.saga import ChoreographedSaga
 
 logger = logging.getLogger(__name__)
@@ -47,6 +47,8 @@ class ChoreographyEngine:
         self._bus = bus
         self._sagas: dict[str, ChoreographedSaga] = {}
         self._running = False
+        # Tracks dispatch closures created per saga so they can be properly unsubscribed.
+        self._closures: dict[str, dict[str, HandlerT]] = {}
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -85,21 +87,22 @@ class ChoreographyEngine:
 
         self._sagas[saga.saga_id] = saga
 
-        for event_type, _method in saga._handlers.items():
-            # Wrap the method so the bus calls saga.handle() → proper routing
+        for event_type in saga._handlers:
+            # Capture saga via default arg to avoid closure-over-loop-variable.
             async def _dispatch(event: Event, _saga: ChoreographedSaga = saga) -> None:
                 await _saga.handle(event)
 
-            # Subscribe once per event type per saga; use the dispatch wrapper
+            # Store the closure so _deregister() can later call bus.unsubscribe().
+            self._closures.setdefault(saga.saga_id, {})[event_type] = _dispatch
             self._bus.subscribe(event_type, _dispatch)
 
         logger.debug("Registered saga %r (%s)", saga.saga_id, saga.name)
 
     def _deregister(self, saga: ChoreographedSaga) -> None:
-        """Unsubscribe the saga's handlers from the bus."""
-        # We cannot easily unsubscribe the closures we created, so we rely on
-        # the engine's stopped state to skip dispatch.  For production use
-        # with external adapters, explicit unsubscription would be wired here.
+        """Unsubscribe the saga's dispatch closures from the bus."""
+        closures = self._closures.pop(saga.saga_id, {})
+        for event_type, closure in closures.items():
+            self._bus.unsubscribe(event_type, closure)
         logger.debug("Deregistered saga %r", saga.saga_id)
 
     def unregister(self, saga_id: str) -> None:

--- a/sagaz/choreography/events.py
+++ b/sagaz/choreography/events.py
@@ -1,0 +1,143 @@
+"""
+Event and EventBus for saga choreography.
+
+``Event`` is a lightweight, immutable message.
+``EventBus`` is an in-process pub/sub bus based on asyncio queues.  It is
+intentionally decoupled from Kafka / RabbitMQ — those are adapters that can
+*publish to* or *subscribe from* this bus.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections import defaultdict
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+from uuid import uuid4
+
+logger = logging.getLogger(__name__)
+
+HandlerT = Callable[["Event"], Awaitable[None]]
+
+
+@dataclass(frozen=True)
+class Event:
+    """
+    Immutable domain event.
+
+    Parameters
+    ----------
+    event_type:
+        Dot-separated event identifier, e.g. ``"order.created"``.
+    data:
+        Arbitrary payload dict.
+    event_id:
+        Auto-generated UUID if not provided.
+    saga_id:
+        Optional correlation ID linking the event to a saga run.
+    created_at:
+        Timestamp; defaults to ``datetime.now(UTC)``.
+    """
+
+    event_type: str
+    data: dict[str, Any] = field(default_factory=dict)
+    event_id: str = field(default_factory=lambda: str(uuid4()))
+    saga_id: str | None = None
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+    def with_saga(self, saga_id: str) -> Event:
+        """Return a new Event with the given saga_id."""
+        return Event(
+            event_type=self.event_type,
+            data=self.data,
+            event_id=self.event_id,
+            saga_id=saga_id,
+            created_at=self.created_at,
+        )
+
+    def __repr__(self) -> str:
+        return f"Event({self.event_type!r}, saga={self.saga_id!r}, id={self.event_id[:8]})"
+
+
+class EventBus:
+    """
+    In-process publish/subscribe event bus.
+
+    Handlers registered for an event type are awaited when an event of
+    that type is published.  Wildcard ``"*"`` handlers receive all events.
+
+    This bus is **not** thread-safe by design; use it within a single
+    asyncio event loop.  For multi-process / distributed use, front it with a
+    Kafka or RabbitMQ adapter.
+    """
+
+    def __init__(self) -> None:
+        self._handlers: dict[str, list[HandlerT]] = defaultdict(list)
+        self._published: list[Event] = []
+        self._lock = asyncio.Lock()
+
+    # ------------------------------------------------------------------
+    # Subscription
+    # ------------------------------------------------------------------
+
+    def subscribe(self, event_type: str, handler: HandlerT) -> None:
+        """
+        Register *handler* for *event_type*.
+
+        Parameters
+        ----------
+        event_type:
+            Exact event type string or ``"*"`` for all events.
+        handler:
+            Async callable ``(Event) -> None``.
+        """
+        self._handlers[event_type].append(handler)
+        logger.debug("Subscribed %s to %r", handler, event_type)
+
+    def unsubscribe(self, event_type: str, handler: HandlerT) -> None:
+        """Remove *handler* from *event_type* subscribers."""
+        try:
+            self._handlers[event_type].remove(handler)
+        except ValueError:
+            pass
+
+    # ------------------------------------------------------------------
+    # Publishing
+    # ------------------------------------------------------------------
+
+    async def publish(self, event: Event) -> None:
+        """
+        Publish *event* to all registered handlers (specific + wildcard).
+
+        All handlers are awaited sequentially.  Errors in individual handlers
+        are logged but do not prevent other handlers from running.
+        """
+        self._published.append(event)
+        handlers = list(self._handlers.get(event.event_type, []))
+        handlers += list(self._handlers.get("*", []))
+
+        for handler in handlers:
+            try:
+                await handler(event)
+            except Exception:
+                logger.exception("Handler %s raised on event %r", handler, event.event_type)
+
+    # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+
+    @property
+    def published(self) -> list[Event]:
+        """All events published since construction (for testing / debugging)."""
+        return list(self._published)
+
+    def clear_history(self) -> None:
+        """Discard the recorded publish history."""
+        self._published.clear()
+
+    def handler_count(self, event_type: str) -> int:
+        """Return the number of handlers registered for *event_type*."""
+        return len(self._handlers.get(event_type, []))

--- a/sagaz/choreography/events.py
+++ b/sagaz/choreography/events.py
@@ -2,14 +2,13 @@
 Event and EventBus for saga choreography.
 
 ``Event`` is a lightweight, immutable message.
-``EventBus`` is an in-process pub/sub bus based on asyncio queues.  It is
-intentionally decoupled from Kafka / RabbitMQ — those are adapters that can
-*publish to* or *subscribe from* this bus.
+``EventBus`` is an in-process pub/sub bus that directly awaits handlers.
+It is intentionally decoupled from Kafka / RabbitMQ — those are adapters
+that can *publish to* or *subscribe from* this bus.
 """
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from collections import defaultdict
 from collections.abc import Awaitable, Callable
@@ -77,7 +76,6 @@ class EventBus:
     def __init__(self) -> None:
         self._handlers: dict[str, list[HandlerT]] = defaultdict(list)
         self._published: list[Event] = []
-        self._lock = asyncio.Lock()
 
     # ------------------------------------------------------------------
     # Subscription

--- a/sagaz/choreography/events.py
+++ b/sagaz/choreography/events.py
@@ -53,7 +53,7 @@ class Event:
         """Return a new Event with the given saga_id."""
         return Event(
             event_type=self.event_type,
-            data=self.data,
+            data=dict(self.data),  # shallow copy — avoids sharing the mutable dict reference
             event_id=self.event_id,
             saga_id=saga_id,
             created_at=self.created_at,
@@ -173,7 +173,7 @@ class EventBus(AbstractEventBus):
         try:
             self._handlers[event_type].remove(handler)
         except ValueError:
-            pass
+            pass  # handler was not registered — silent no-op
 
     # ------------------------------------------------------------------
     # Publishing

--- a/sagaz/choreography/events.py
+++ b/sagaz/choreography/events.py
@@ -2,14 +2,16 @@
 Event and EventBus for saga choreography.
 
 ``Event`` is a lightweight, immutable message.
+``AbstractEventBus`` is the shared protocol every transport backend implements.
 ``EventBus`` is an in-process pub/sub bus that directly awaits handlers.
-It is intentionally decoupled from Kafka / RabbitMQ — those are adapters
-that can *publish to* or *subscribe from* this bus.
+Distributed transports (Redis Streams, Kafka, RabbitMQ) live in
+``sagaz.choreography.buses`` and all extend ``AbstractEventBus``.
 """
 
 from __future__ import annotations
 
 import logging
+from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
@@ -61,7 +63,78 @@ class Event:
         return f"Event({self.event_type!r}, saga={self.saga_id!r}, id={self.event_id[:8]})"
 
 
-class EventBus:
+class AbstractEventBus(ABC):
+    """
+    Shared contract for all EventBus transport backends.
+
+    Implementations
+    ---------------
+    - ``EventBus``              — in-process asyncio (zero dependencies)
+    - ``RedisStreamsEventBus``  — Redis Streams (requires ``sagaz[redis]``)
+    - ``KafkaEventBus``        — Apache Kafka   (requires ``sagaz[kafka]``)
+    - ``RabbitMQEventBus``     — RabbitMQ/AMQP  (requires ``sagaz[rabbitmq]``)
+
+    Lifecycle
+    ---------
+    Call ``await bus.start()`` before publishing or subscribing with
+    distributed backends.  In-process ``EventBus`` treats ``start``/``stop``
+    as no-ops.
+    """
+
+    # ------------------------------------------------------------------
+    # Subscription (abstract — every backend must implement)
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def subscribe(self, event_type: str, handler: HandlerT) -> None:
+        """Register *handler* for *event_type* (``"*"`` = all events)."""
+
+    @abstractmethod
+    def unsubscribe(self, event_type: str, handler: HandlerT) -> None:
+        """Remove *handler* from *event_type* subscribers."""
+
+    # ------------------------------------------------------------------
+    # Publishing (abstract)
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    async def publish(self, event: Event) -> None:
+        """Publish *event* to all registered handlers."""
+
+    # ------------------------------------------------------------------
+    # Lifecycle (optional — default implementations are no-ops)
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Connect and start background reader, if applicable.
+
+        No-op for in-process buses.  Distributed backends must override.
+        """
+
+    async def stop(self) -> None:
+        """Disconnect and stop background reader, if applicable.
+
+        No-op for in-process buses.  Distributed backends must override.
+        """
+
+    # ------------------------------------------------------------------
+    # Testing helpers (default implementations return safe empty values)
+    # ------------------------------------------------------------------
+
+    @property
+    def published(self) -> list[Event]:
+        """Events published via this bus instance (empty if not tracked)."""
+        return []
+
+    def clear_history(self) -> None:
+        """Discard recorded publish history (no-op if not tracked)."""
+
+    def handler_count(self, event_type: str) -> int:
+        """Number of handlers registered for *event_type*."""
+        return 0
+
+
+class EventBus(AbstractEventBus):
     """
     In-process publish/subscribe event bus.
 

--- a/sagaz/choreography/saga.py
+++ b/sagaz/choreography/saga.py
@@ -1,0 +1,111 @@
+"""
+ChoreographedSaga — base class for event-driven saga participants.
+
+A ``ChoreographedSaga`` discovers all ``@on_event``-decorated methods at
+construction time and exposes them via ``_handlers``.  It is registered with
+a ``ChoreographyEngine`` that subscribes each handler to the ``EventBus``.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from typing import Any
+
+from sagaz.choreography.decorators import get_event_type
+from sagaz.choreography.events import Event
+
+logger = logging.getLogger(__name__)
+
+
+class ChoreographedSaga:
+    """
+    Base class for saga participants in a choreography.
+
+    Subclasses declare event handlers using the ``@on_event`` decorator.
+    The ``ChoreographyEngine`` subscribes these handlers to the ``EventBus``
+    when ``engine.register(saga)`` is called.
+
+    Parameters
+    ----------
+    saga_id:
+        Optional correlation ID.  Auto-assigned if omitted.
+    name:
+        Human-readable saga name for logging.
+    """
+
+    def __init__(
+        self,
+        saga_id: str | None = None,
+        name: str | None = None,
+    ) -> None:
+        from uuid import uuid4
+
+        self.saga_id: str = saga_id or str(uuid4())
+        self.name: str = name or type(self).__name__
+        self._events_handled: list[Event] = []
+        self._handlers: dict[str, Any] = {}  # event_type → bound method
+        self._discover_handlers()
+
+    # ------------------------------------------------------------------
+    # Handler discovery
+    # ------------------------------------------------------------------
+
+    def _discover_handlers(self) -> None:
+        """
+        Inspect all methods and collect those marked with ``@on_event``.
+        Populates ``self._handlers`` as ``{event_type: bound_method}``.
+        """
+        for _name, method in inspect.getmembers(self, predicate=inspect.ismethod):
+            event_type = get_event_type(method)
+            if event_type is not None:
+                if event_type in self._handlers:
+                    logger.warning(
+                        "%s has multiple handlers for event type %r; last one wins.",
+                        self.name,
+                        event_type,
+                    )
+                self._handlers[event_type] = method
+                logger.debug(
+                    "%s registered handler %r for %r",
+                    self.name,
+                    _name,
+                    event_type,
+                )
+
+    # ------------------------------------------------------------------
+    # Event handling
+    # ------------------------------------------------------------------
+
+    async def handle(self, event: Event) -> None:
+        """
+        Dispatch *event* to the appropriate ``@on_event`` handler.
+
+        Looks up by exact event type first, then by ``"*"`` wildcard.
+
+        Parameters
+        ----------
+        event:
+            The incoming domain event.
+        """
+        handler = self._handlers.get(event.event_type) or self._handlers.get("*")
+        if handler is None:
+            logger.debug("%s has no handler for %r; ignoring", self.name, event.event_type)
+            return
+
+        self._events_handled.append(event)
+        logger.debug("%s handling %r (saga_id=%s)", self.name, event.event_type, self.saga_id)
+        await handler(event)
+
+    # ------------------------------------------------------------------
+    # Introspection helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def events_handled(self) -> list[Event]:
+        """All events dispatched to this saga since construction."""
+        return list(self._events_handled)
+
+    def handles(self, event_type: str) -> bool:
+        """Return *True* if this saga has a handler for *event_type*."""
+        return event_type in self._handlers or "*" in self._handlers

--- a/tests/integration/test_choreography_containers.py
+++ b/tests/integration/test_choreography_containers.py
@@ -1,0 +1,433 @@
+"""
+Integration tests for choreography EventBus backends using real broker containers.
+
+Each test class exercises a concrete ``AbstractEventBus`` implementation against
+a live broker started by testcontainers.  Tests are skipped automatically when:
+
+- Docker / testcontainers is not available.
+- The required optional package (aiokafka / aio-pika / redis) is missing.
+- ``--no-containers`` CLI flag or ``SAGAZ_NO_CONTAINERS=1`` env var is set.
+
+Run only these tests:
+    pytest tests/integration/test_choreography_containers.py -v -m integration
+
+Run with containers pre-started in parallel (faster for full suite):
+    pytest tests/integration/test_choreography_containers.py -v -m integration \\
+        --parallel-containers
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from sagaz.choreography.events import AbstractEventBus, Event
+
+pytestmark = pytest.mark.integration
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_TIMEOUT = 10.0  # seconds — generous enough for slow CI runners
+
+
+async def _wait_for(condition, timeout: float = _TIMEOUT, poll: float = 0.05) -> bool:
+    """Poll *condition()* until True or *timeout* expires.  Returns True on success."""
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        if condition():
+            return True
+        await asyncio.sleep(poll)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Redis Streams EventBus
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xdist_group(name="containers")
+class TestRedisStreamsEventBusIntegration:
+    """Integration tests for RedisStreamsEventBus against a live Redis container."""
+
+    @pytest.mark.asyncio
+    async def test_publish_subscribe_round_trip(self, redis_container) -> None:
+        """A published event must be received by a subscribed handler."""
+        from sagaz.choreography.buses.redis_streams import (
+            RedisStreamsBusConfig,
+            RedisStreamsEventBus,
+        )
+
+        host = redis_container.get_container_host_ip()
+        port = redis_container.get_exposed_port(6379)
+        config = RedisStreamsBusConfig(
+            url=f"redis://{host}:{port}",
+            stream_name="test.choreography.rtt",
+            consumer_group="test-rtt",
+            consumer_name="worker-1",
+            block_timeout_ms=200,
+        )
+        bus = RedisStreamsEventBus(config)
+        received: list[Event] = []
+
+        async def handler(e: Event) -> None:
+            received.append(e)
+
+        try:
+            await bus.start()
+            bus.subscribe("order.created", handler)
+            await bus.publish(Event("order.created", {"order_id": "ORD-1"}))
+
+            assert await _wait_for(lambda: len(received) >= 1), (
+                "Handler was not called within timeout"
+            )
+        finally:
+            await bus.stop()
+
+        assert len(received) == 1
+        assert received[0].event_type == "order.created"
+        assert received[0].data["order_id"] == "ORD-1"
+
+    @pytest.mark.asyncio
+    async def test_wildcard_handler_receives_all_event_types(self, redis_container) -> None:
+        """A ``*`` handler must receive events of any type."""
+        from sagaz.choreography.buses.redis_streams import (
+            RedisStreamsBusConfig,
+            RedisStreamsEventBus,
+        )
+
+        host = redis_container.get_container_host_ip()
+        port = redis_container.get_exposed_port(6379)
+        config = RedisStreamsBusConfig(
+            url=f"redis://{host}:{port}",
+            stream_name="test.choreography.wildcard",
+            consumer_group="test-wildcard",
+            consumer_name="worker-1",
+            block_timeout_ms=200,
+        )
+        bus = RedisStreamsEventBus(config)
+        received_types: list[str] = []
+
+        bus_started = False
+        try:
+            await bus.start()
+            bus_started = True
+            bus.subscribe("*", lambda e: received_types.append(e.event_type))
+
+            await bus.publish(Event("alpha.event"))
+            await bus.publish(Event("beta.event"))
+
+            assert await _wait_for(lambda: len(received_types) >= 2)
+        finally:
+            if bus_started:
+                await bus.stop()
+
+        assert "alpha.event" in received_types
+        assert "beta.event" in received_types
+
+    @pytest.mark.asyncio
+    async def test_unsubscribe_stops_delivery(self, redis_container) -> None:
+        """Unsubscribed handler must not receive events published after unsubscription."""
+        from sagaz.choreography.buses.redis_streams import (
+            RedisStreamsBusConfig,
+            RedisStreamsEventBus,
+        )
+
+        host = redis_container.get_container_host_ip()
+        port = redis_container.get_exposed_port(6379)
+        config = RedisStreamsBusConfig(
+            url=f"redis://{host}:{port}",
+            stream_name="test.choreography.unsub",
+            consumer_group="test-unsub",
+            consumer_name="worker-1",
+            block_timeout_ms=200,
+        )
+        bus = RedisStreamsEventBus(config)
+        calls = 0
+
+        async def handler(e: Event) -> None:
+            nonlocal calls
+            calls += 1
+
+        try:
+            await bus.start()
+            bus.subscribe("x.event", handler)
+            await bus.publish(Event("x.event"))
+            assert await _wait_for(lambda: calls >= 1)
+
+            bus.unsubscribe("x.event", handler)
+            before = calls
+            await bus.publish(Event("x.event"))
+            await asyncio.sleep(0.5)  # allow any in-flight delivery
+        finally:
+            await bus.stop()
+
+        assert calls == before, "Handler received event after unsubscription"
+
+    @pytest.mark.asyncio
+    async def test_start_idempotent(self, redis_container) -> None:
+        """Calling start() twice must not raise or create duplicate reader tasks."""
+        from sagaz.choreography.buses.redis_streams import (
+            RedisStreamsBusConfig,
+            RedisStreamsEventBus,
+        )
+
+        host = redis_container.get_container_host_ip()
+        port = redis_container.get_exposed_port(6379)
+        config = RedisStreamsBusConfig(
+            url=f"redis://{host}:{port}",
+            stream_name="test.choreography.idem",
+            consumer_group="test-idem",
+            consumer_name="worker-1",
+            block_timeout_ms=200,
+        )
+        bus = RedisStreamsEventBus(config)
+        try:
+            await bus.start()
+            first_task = bus._reader_task
+            await bus.start()  # must be a no-op
+            assert bus._reader_task is first_task
+        finally:
+            await bus.stop()
+
+
+# ---------------------------------------------------------------------------
+# Kafka EventBus
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xdist_group(name="containers")
+class TestKafkaEventBusIntegration:
+    """Integration tests for KafkaEventBus against a live Kafka container."""
+
+    @pytest.mark.asyncio
+    async def test_publish_subscribe_round_trip(self, kafka_container) -> None:
+        """A published event must be received by a subscribed handler."""
+        from sagaz.choreography.buses.kafka import (
+            KafkaEventBus,
+            KafkaEventBusConfig,
+        )
+
+        bootstrap = kafka_container.get_bootstrap_server()
+        config = KafkaEventBusConfig(
+            bootstrap_servers=bootstrap,
+            topic="test.choreography",
+            consumer_group="test-cg-rtt",
+            consumer_name="worker-test",
+            auto_offset_reset="earliest",
+        )
+        bus = KafkaEventBus(config)
+        received: list[Event] = []
+
+        async def handler(e: Event) -> None:
+            received.append(e)
+
+        try:
+            await bus.start()
+            bus.subscribe("order.created", handler)
+            await bus.publish(Event("order.created", {"order_id": "ORD-KAFKA-1"}))
+
+            assert await _wait_for(lambda: len(received) >= 1, timeout=30.0), (
+                "Kafka handler not called within timeout"
+            )
+        finally:
+            await bus.stop()
+
+        assert received[0].event_type == "order.created"
+        assert received[0].data["order_id"] == "ORD-KAFKA-1"
+
+    @pytest.mark.asyncio
+    async def test_wildcard_handler(self, kafka_container) -> None:
+        """A ``*`` wildcard handler must receive all published events."""
+        from sagaz.choreography.buses.kafka import (
+            KafkaEventBus,
+            KafkaEventBusConfig,
+        )
+
+        bootstrap = kafka_container.get_bootstrap_server()
+        config = KafkaEventBusConfig(
+            bootstrap_servers=bootstrap,
+            topic="test.choreography.wildcard",
+            consumer_group="test-cg-wildcard",
+            consumer_name="worker-test",
+            auto_offset_reset="earliest",
+        )
+        bus = KafkaEventBus(config)
+        received: list[str] = []
+
+        try:
+            await bus.start()
+            bus.subscribe("*", lambda e: received.append(e.event_type))
+            await bus.publish(Event("alpha.event"))
+            await bus.publish(Event("beta.event"))
+
+            assert await _wait_for(lambda: len(received) >= 2, timeout=30.0)
+        finally:
+            await bus.stop()
+
+        assert "alpha.event" in received
+        assert "beta.event" in received
+
+    @pytest.mark.asyncio
+    async def test_start_idempotent(self, kafka_container) -> None:
+        """Calling start() twice must not create a duplicate reader task."""
+        from sagaz.choreography.buses.kafka import (
+            KafkaEventBus,
+            KafkaEventBusConfig,
+        )
+
+        bootstrap = kafka_container.get_bootstrap_server()
+        config = KafkaEventBusConfig(
+            bootstrap_servers=bootstrap,
+            topic="test.choreography.idem",
+            consumer_group="test-cg-idem",
+            consumer_name="worker-test",
+            auto_offset_reset="latest",
+        )
+        bus = KafkaEventBus(config)
+        try:
+            await bus.start()
+            first_task = bus._reader_task
+            await bus.start()
+            assert bus._reader_task is first_task
+        finally:
+            await bus.stop()
+
+
+# ---------------------------------------------------------------------------
+# RabbitMQ EventBus
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xdist_group(name="containers")
+class TestRabbitMQEventBusIntegration:
+    """Integration tests for RabbitMQEventBus against a live RabbitMQ container."""
+
+    def _amqp_url(self, container) -> str:
+        try:
+            return container.get_connection_url()
+        except AttributeError:
+            host = container.get_container_host_ip()
+            port = container.get_exposed_port(5672)
+            return f"amqp://guest:guest@{host}:{port}/"
+
+    @pytest.mark.asyncio
+    async def test_publish_subscribe_round_trip(self, rabbitmq_container) -> None:
+        """A published event must be received by a subscribed handler."""
+        from sagaz.choreography.buses.rabbitmq import (
+            RabbitMQEventBus,
+            RabbitMQEventBusConfig,
+        )
+
+        config = RabbitMQEventBusConfig(
+            url=self._amqp_url(rabbitmq_container),
+            exchange_name="test.choreo",
+            queue_name="test.choreo.queue",
+        )
+        bus = RabbitMQEventBus(config)
+        received: list[Event] = []
+
+        async def handler(e: Event) -> None:
+            received.append(e)
+
+        try:
+            await bus.start()
+            bus.subscribe("order.created", handler)
+            await bus.publish(Event("order.created", {"order_id": "ORD-AMQ-1"}))
+
+            assert await _wait_for(lambda: len(received) >= 1), (
+                "RabbitMQ handler not called within timeout"
+            )
+        finally:
+            await bus.stop()
+
+        assert received[0].event_type == "order.created"
+        assert received[0].data["order_id"] == "ORD-AMQ-1"
+
+    @pytest.mark.asyncio
+    async def test_wildcard_handler(self, rabbitmq_container) -> None:
+        """A ``*`` wildcard handler must receive all published events."""
+        from sagaz.choreography.buses.rabbitmq import (
+            RabbitMQEventBus,
+            RabbitMQEventBusConfig,
+        )
+
+        config = RabbitMQEventBusConfig(
+            url=self._amqp_url(rabbitmq_container),
+            exchange_name="test.choreo.wildcard",
+            queue_name="test.choreo.wildcard.queue",
+        )
+        bus = RabbitMQEventBus(config)
+        received: list[str] = []
+
+        try:
+            await bus.start()
+            bus.subscribe("*", lambda e: received.append(e.event_type))
+            await bus.publish(Event("alpha.event"))
+            await bus.publish(Event("beta.event"))
+
+            assert await _wait_for(lambda: len(received) >= 2)
+        finally:
+            await bus.stop()
+
+        assert "alpha.event" in received
+        assert "beta.event" in received
+
+    @pytest.mark.asyncio
+    async def test_start_idempotent(self, rabbitmq_container) -> None:
+        """Calling start() twice must not reconnect."""
+        from sagaz.choreography.buses.rabbitmq import (
+            RabbitMQEventBus,
+            RabbitMQEventBusConfig,
+        )
+
+        config = RabbitMQEventBusConfig(
+            url=self._amqp_url(rabbitmq_container),
+            exchange_name="test.choreo.idem",
+            queue_name="test.choreo.idem.queue",
+        )
+        bus = RabbitMQEventBus(config)
+        try:
+            await bus.start()
+            first_conn = bus._connection
+            await bus.start()
+            assert bus._connection is first_conn
+        finally:
+            await bus.stop()
+
+    @pytest.mark.asyncio
+    async def test_unsubscribe_stops_delivery(self, rabbitmq_container) -> None:
+        """Unsubscribed handler must not receive events published after unsubscription."""
+        from sagaz.choreography.buses.rabbitmq import (
+            RabbitMQEventBus,
+            RabbitMQEventBusConfig,
+        )
+
+        config = RabbitMQEventBusConfig(
+            url=self._amqp_url(rabbitmq_container),
+            exchange_name="test.choreo.unsub",
+            queue_name="test.choreo.unsub.queue",
+        )
+        bus = RabbitMQEventBus(config)
+        calls = 0
+
+        async def handler(e: Event) -> None:
+            nonlocal calls
+            calls += 1
+
+        try:
+            await bus.start()
+            bus.subscribe("x.event", handler)
+            await bus.publish(Event("x.event"))
+            assert await _wait_for(lambda: calls >= 1)
+
+            bus.unsubscribe("x.event", handler)
+            before = calls
+            await bus.publish(Event("x.event"))
+            await asyncio.sleep(0.5)
+        finally:
+            await bus.stop()
+
+        assert calls == before, "Handler received event after unsubscription"

--- a/tests/integration/test_choreography_performance.py
+++ b/tests/integration/test_choreography_performance.py
@@ -1,0 +1,385 @@
+"""
+Performance benchmarks for the sagaz choreography module.
+
+Measures in-process EventBus throughput and latency under various loads:
+
+1. Publish throughput — raw events/sec through the in-process EventBus.
+2. Fan-out throughput — one publisher → N concurrent handlers.
+3. Event-chain latency — end-to-end latency for a multi-step saga chain.
+4. Engine registration overhead — cost of register/unregister per saga.
+
+Run with:
+    pytest tests/integration/test_choreography_performance.py -v -m performance
+
+"""
+
+from __future__ import annotations
+
+import asyncio
+import statistics
+import time
+from dataclasses import dataclass
+
+import pytest
+
+from sagaz.choreography import (
+    ChoreographedSaga,
+    ChoreographyEngine,
+    Event,
+    EventBus,
+    on_event,
+)
+
+pytestmark = pytest.mark.performance
+
+
+# ---------------------------------------------------------------------------
+# Benchmark configuration
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BenchConfig:
+    """Tunable parameters for each benchmark scenario."""
+
+    iterations: int
+    concurrency: int
+
+
+LOCAL = BenchConfig(iterations=500, concurrency=10)
+CI = BenchConfig(iterations=200, concurrency=5)
+
+
+def _config() -> BenchConfig:
+    """Return LOCAL config (CI guard can lower it via env)."""
+    import os
+
+    return CI if os.getenv("CI") else LOCAL
+
+
+# ---------------------------------------------------------------------------
+# Result dataclass and helpers
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BenchResult:
+    total: int
+    elapsed: float
+    latencies_ms: list[float]
+
+    @property
+    def throughput(self) -> float:
+        return self.total / self.elapsed if self.elapsed else 0.0
+
+    @property
+    def p50(self) -> float:
+        return statistics.median(self.latencies_ms) if self.latencies_ms else 0.0
+
+    @property
+    def p95(self) -> float:
+        if not self.latencies_ms:
+            return 0.0
+        s = sorted(self.latencies_ms)
+        return s[int(len(s) * 0.95)]
+
+    @property
+    def p99(self) -> float:
+        if not self.latencies_ms:
+            return 0.0
+        s = sorted(self.latencies_ms)
+        return s[int(len(s) * 0.99)]
+
+    @property
+    def mean(self) -> float:
+        return statistics.mean(self.latencies_ms) if self.latencies_ms else 0.0
+
+    def print_summary(self, label: str) -> None:
+        print(
+            f"\n--- {label} ---\n"
+            f"  iterations : {self.total}\n"
+            f"  elapsed    : {self.elapsed:.3f}s\n"
+            f"  throughput : {self.throughput:,.0f} ops/sec\n"
+            f"  mean       : {self.mean:.4f} ms\n"
+            f"  p50        : {self.p50:.4f} ms\n"
+            f"  p95        : {self.p95:.4f} ms\n"
+            f"  p99        : {self.p99:.4f} ms"
+        )
+
+
+async def _run_batched(coro_factory, iterations: int, concurrency: int) -> BenchResult:
+    """Run *coro_factory()* *iterations* times in batches of *concurrency*."""
+    latencies: list[float] = []
+    t0 = time.perf_counter()
+    remaining = iterations
+    while remaining > 0:
+        batch = min(concurrency, remaining)
+        t_batch = time.perf_counter()
+        await asyncio.gather(*[coro_factory() for _ in range(batch)])
+        elapsed_batch = (time.perf_counter() - t_batch) * 1000 / batch
+        latencies.extend([elapsed_batch] * batch)
+        remaining -= batch
+    return BenchResult(
+        total=iterations,
+        elapsed=time.perf_counter() - t0,
+        latencies_ms=latencies,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Saga definitions used across benchmarks
+# ---------------------------------------------------------------------------
+
+
+class NoopSaga(ChoreographedSaga):
+    """A saga with one event handler that does nothing — baseline overhead."""
+
+    @on_event("bench.event")
+    async def handle(self, event: Event) -> None:
+        pass  # intentional no-op for measuring dispatch overhead
+
+
+class FanOutSaga(ChoreographedSaga):
+    """Receives fan-out events and records arrival."""
+
+    def __init__(self, saga_id: str, collector: list[str]) -> None:
+        super().__init__(saga_id=saga_id)
+        self._collector = collector
+
+    @on_event("fanout.event")
+    async def handle(self, event: Event) -> None:
+        self._collector.append(self.saga_id)
+
+
+class ChainStep(ChoreographedSaga):
+    """One link in a multi-step event chain."""
+
+    def __init__(
+        self,
+        saga_id: str,
+        listen_for: str,
+        emit: str | None,
+        bus: EventBus,
+        trace: list[str],
+    ) -> None:
+        super().__init__(saga_id=saga_id)
+        self._emit_event = emit
+        self._bus = bus
+        self._trace = trace
+        # Register the handler manually after init to support parameterized event types.
+        self._handlers[listen_for] = self._step
+
+    async def _step(self, event: Event) -> None:
+        self._trace.append(self.saga_id)
+        if self._emit_event:
+            await self._bus.publish(Event(self._emit_event, event.data))
+
+
+# ---------------------------------------------------------------------------
+# Benchmarks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pub_sub_throughput() -> None:
+    """Measure raw publish → single handler throughput on the in-process EventBus."""
+    cfg = _config()
+    bus = EventBus()
+    received: list[Event] = []
+
+    async def handler(e: Event) -> None:
+        received.append(e)
+
+    bus.subscribe("bench.event", handler)
+
+    async def one_publish() -> None:
+        await bus.publish(Event("bench.event", {"n": 1}))
+
+    result = await _run_batched(one_publish, cfg.iterations, cfg.concurrency)
+    result.print_summary("Publish → single handler throughput")
+
+    assert len(received) == cfg.iterations
+    assert result.throughput > 100, f"throughput too low: {result.throughput:.0f} ops/sec"
+    assert result.p99 < 50, f"p99 too high: {result.p99:.2f} ms"
+
+
+@pytest.mark.asyncio
+async def test_engine_dispatch_throughput() -> None:
+    """Measure ChoreographyEngine dispatch throughput (register + publish)."""
+    cfg = _config()
+    bus = EventBus()
+    engine = ChoreographyEngine(bus)
+
+    dispatched: list[str] = []
+    saga = NoopSaga(saga_id="bench-saga")
+    # Override handle to record dispatches.
+    original_handle = saga.handle
+
+    async def recording_handle(event: Event) -> None:
+        dispatched.append(event.event_type)
+        await original_handle(event)
+
+    saga.handle = recording_handle  # type: ignore[method-assign]
+
+    engine.register(saga)
+    await engine.start()
+
+    async def fire_one() -> None:
+        await bus.publish(Event("bench.event", {"n": 1}))
+
+    result = await _run_batched(fire_one, cfg.iterations, cfg.concurrency)
+    await engine.stop()
+
+    result.print_summary("ChoreographyEngine dispatch throughput")
+
+    assert len(dispatched) == cfg.iterations
+    assert result.throughput > 100, f"throughput too low: {result.throughput:.0f} ops/sec"
+
+
+@pytest.mark.asyncio
+async def test_fan_out_throughput() -> None:
+    """Measure fan-out: one event published to N sagas simultaneously."""
+    cfg = _config()
+    fan_out_size = 10
+    bus = EventBus()
+    engine = ChoreographyEngine(bus)
+    collector: list[str] = []
+
+    for i in range(fan_out_size):
+        engine.register(FanOutSaga(saga_id=f"fan-{i}", collector=collector))
+
+    await engine.start()
+
+    async def one_event() -> None:
+        collector.clear()
+        await bus.publish(Event("fanout.event", {}))
+
+    latencies: list[float] = []
+    t0 = time.perf_counter()
+    for _ in range(cfg.iterations):
+        t1 = time.perf_counter()
+        collector.clear()
+        await bus.publish(Event("fanout.event", {}))
+        latencies.append((time.perf_counter() - t1) * 1000)
+
+    result = BenchResult(
+        total=cfg.iterations,
+        elapsed=time.perf_counter() - t0,
+        latencies_ms=latencies,
+    )
+    await engine.stop()
+
+    result.print_summary(f"Fan-out → {fan_out_size} sagas throughput")
+
+    assert result.throughput > 50, f"throughput too low: {result.throughput:.0f} ops/sec"
+    assert result.p99 < 100, f"p99 too high: {result.p99:.2f} ms"
+
+
+@pytest.mark.asyncio
+async def test_event_chain_latency() -> None:
+    """
+    Measure end-to-end latency for a 4-step event chain.
+
+    Chain: trigger → step-a → step-b → step-c → step-d (terminal)
+    """
+    iterations = 50  # chains take more time — keep count lower
+    bus = EventBus()
+    engine = ChoreographyEngine(bus)
+    trace: list[str] = []
+
+    chain = [
+        ChainStep("step-a", "chain.trigger", "chain.b", bus, trace),
+        ChainStep("step-b", "chain.b", "chain.c", bus, trace),
+        ChainStep("step-c", "chain.c", "chain.d", bus, trace),
+        ChainStep("step-d", "chain.d", None, bus, trace),
+    ]
+    for step in chain:
+        engine.register(step)
+
+    await engine.start()
+
+    latencies_ms: list[float] = []
+    t0 = time.perf_counter()
+    for _ in range(iterations):
+        trace.clear()
+        t1 = time.perf_counter()
+        await bus.publish(Event("chain.trigger", {"run": 1}))
+        latencies_ms.append((time.perf_counter() - t1) * 1000)
+
+    result = BenchResult(
+        total=iterations,
+        elapsed=time.perf_counter() - t0,
+        latencies_ms=latencies_ms,
+    )
+    await engine.stop()
+
+    result.print_summary("4-step event chain end-to-end latency")
+
+    assert result.p99 < 50, f"chain p99 too high: {result.p99:.2f} ms"
+    assert result.mean < 10, f"chain mean too high: {result.mean:.2f} ms"
+
+
+@pytest.mark.asyncio
+async def test_register_unregister_throughput() -> None:
+    """Measure the overhead of engine.register() / engine.unregister() cycles."""
+    cfg = _config()
+    bus = EventBus()
+    engine = ChoreographyEngine(bus)
+    await engine.start()
+
+    latencies_ms: list[float] = []
+    t0 = time.perf_counter()
+    for i in range(cfg.iterations):
+        saga = NoopSaga(saga_id=f"reg-{i}")
+        t1 = time.perf_counter()
+        engine.register(saga)
+        engine.unregister(saga.saga_id)
+        latencies_ms.append((time.perf_counter() - t1) * 1000)
+
+    result = BenchResult(
+        total=cfg.iterations,
+        elapsed=time.perf_counter() - t0,
+        latencies_ms=latencies_ms,
+    )
+    await engine.stop()
+
+    result.print_summary("Register + unregister throughput")
+
+    assert result.throughput > 500, f"register/unregister too slow: {result.throughput:.0f} ops/sec"
+    assert result.p99 < 10, f"p99 too high: {result.p99:.2f} ms"
+
+
+@pytest.mark.asyncio
+async def test_wildcard_handler_throughput() -> None:
+    """Publish diverse event types to a bus with a single wildcard handler."""
+    cfg = _config()
+    bus = EventBus()
+    received = 0
+    event_types = [f"domain.event.{i}" for i in range(20)]
+
+    async def wildcard(e: Event) -> None:
+        nonlocal received
+        received += 1
+
+    bus.subscribe("*", wildcard)
+
+    import random
+
+    latencies_ms: list[float] = []
+    t0 = time.perf_counter()
+    for _ in range(cfg.iterations):
+        evt = Event(random.choice(event_types), {"n": 1})
+        t1 = time.perf_counter()
+        await bus.publish(evt)
+        latencies_ms.append((time.perf_counter() - t1) * 1000)
+
+    result = BenchResult(
+        total=cfg.iterations,
+        elapsed=time.perf_counter() - t0,
+        latencies_ms=latencies_ms,
+    )
+
+    result.print_summary("Wildcard handler throughput (20 distinct event types)")
+
+    assert received == cfg.iterations
+    assert result.throughput > 100, f"throughput too low: {result.throughput:.0f} ops/sec"

--- a/tests/unit/test_bus_factory.py
+++ b/tests/unit/test_bus_factory.py
@@ -1,0 +1,57 @@
+"""
+Unit tests for create_event_bus factory.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sagaz.choreography.buses.factory import BusBackend, create_event_bus
+from sagaz.choreography.events import AbstractEventBus, EventBus
+
+
+def test_memory_returns_event_bus() -> None:
+    bus = create_event_bus("memory")
+    assert isinstance(bus, EventBus)
+    assert isinstance(bus, AbstractEventBus)
+
+
+def test_memory_via_enum() -> None:
+    bus = create_event_bus(BusBackend.MEMORY)
+    assert isinstance(bus, EventBus)
+
+
+def test_redis_returns_redis_streams_bus() -> None:
+    from sagaz.choreography.buses.redis_streams import RedisStreamsEventBus
+
+    bus = create_event_bus("redis")
+    assert isinstance(bus, RedisStreamsEventBus)
+    assert isinstance(bus, AbstractEventBus)
+
+
+def test_kafka_returns_kafka_bus() -> None:
+    from sagaz.choreography.buses.kafka import KafkaEventBus
+
+    bus = create_event_bus("kafka")
+    assert isinstance(bus, KafkaEventBus)
+    assert isinstance(bus, AbstractEventBus)
+
+
+def test_rabbitmq_returns_rabbitmq_bus() -> None:
+    from sagaz.choreography.buses.rabbitmq import RabbitMQEventBus
+
+    bus = create_event_bus("rabbitmq")
+    assert isinstance(bus, RabbitMQEventBus)
+    assert isinstance(bus, AbstractEventBus)
+
+
+def test_unknown_backend_raises_value_error() -> None:
+    with pytest.raises(ValueError, match="Unknown bus backend"):
+        create_event_bus("nats")
+
+
+def test_backend_enum_values() -> None:
+    assert BusBackend.MEMORY == "memory"
+    assert BusBackend.REDIS == "redis"
+    assert BusBackend.KAFKA == "kafka"
+    assert BusBackend.RABBITMQ == "rabbitmq"

--- a/tests/unit/test_choreography.py
+++ b/tests/unit/test_choreography.py
@@ -1,0 +1,371 @@
+"""
+Unit tests for sagaz.choreography — Event, EventBus, ChoreographedSaga,
+ChoreographyEngine, and @on_event decorator.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from sagaz.choreography import (
+    ChoreographedSaga,
+    ChoreographyEngine,
+    Event,
+    EventBus,
+    on_event,
+)
+from sagaz.choreography.decorators import get_event_type
+
+# ---------------------------------------------------------------------------
+# Event
+# ---------------------------------------------------------------------------
+
+
+class TestEvent:
+    def test_defaults_are_set(self):
+        e = Event("order.created", {"order_id": "ORD-1"})
+        assert e.event_type == "order.created"
+        assert e.data["order_id"] == "ORD-1"
+        assert e.event_id  # non-empty UUID
+        assert e.saga_id is None
+        assert e.created_at is not None
+
+    def test_frozen_prevents_mutation(self):
+        e = Event("order.created")
+        with pytest.raises((TypeError, AttributeError)):
+            e.event_type = "other"  # type: ignore[misc]
+
+    def test_with_saga_returns_new_event(self):
+        e = Event("order.created")
+        e2 = e.with_saga("saga-123")
+        assert e2.saga_id == "saga-123"
+        assert e.saga_id is None  # original unchanged
+        assert e2.event_id == e.event_id  # same id, new saga ref
+
+    def test_repr_contains_type(self):
+        e = Event("order.created")
+        assert "order.created" in repr(e)
+
+
+# ---------------------------------------------------------------------------
+# EventBus
+# ---------------------------------------------------------------------------
+
+
+class TestEventBus:
+    @pytest.mark.asyncio
+    async def test_subscribe_and_publish(self):
+        bus = EventBus()
+        received: list[Event] = []
+
+        async def handler(e: Event) -> None:
+            received.append(e)
+
+        bus.subscribe("order.created", handler)
+        await bus.publish(Event("order.created", {"order_id": "1"}))
+        assert len(received) == 1
+
+    @pytest.mark.asyncio
+    async def test_wildcard_receives_all(self):
+        bus = EventBus()
+        received: list[Event] = []
+
+        async def wildcard(e: Event) -> None:
+            received.append(e)
+
+        bus.subscribe("*", wildcard)
+        await bus.publish(Event("order.created"))
+        await bus.publish(Event("payment.charged"))
+        assert len(received) == 2
+
+    @pytest.mark.asyncio
+    async def test_unsubscribe_removes_handler(self):
+        bus = EventBus()
+        received: list[Event] = []
+
+        async def handler(e: Event) -> None:
+            received.append(e)
+
+        bus.subscribe("order.created", handler)
+        bus.unsubscribe("order.created", handler)
+        await bus.publish(Event("order.created"))
+        assert len(received) == 0
+
+    @pytest.mark.asyncio
+    async def test_published_history_is_recorded(self):
+        bus = EventBus()
+        await bus.publish(Event("order.created"))
+        await bus.publish(Event("payment.charged"))
+        assert len(bus.published) == 2
+
+    def test_clear_history(self):
+        bus = EventBus()
+        asyncio.get_event_loop().run_until_complete(bus.publish(Event("x")))
+        bus.clear_history()
+        assert bus.published == []
+
+    @pytest.mark.asyncio
+    async def test_handler_count(self):
+        bus = EventBus()
+
+        async def h1(e):
+            pass
+
+        async def h2(e):
+            pass
+
+        bus.subscribe("order.created", h1)
+        bus.subscribe("order.created", h2)
+        assert bus.handler_count("order.created") == 2
+
+    @pytest.mark.asyncio
+    async def test_handler_exception_does_not_stop_other_handlers(self):
+        """A failing handler should not prevent others from running."""
+        bus = EventBus()
+        second_called = []
+
+        async def bad_handler(e: Event) -> None:
+            msg = "broken"
+            raise RuntimeError(msg)
+
+        async def good_handler(e: Event) -> None:
+            second_called.append(True)
+
+        bus.subscribe("order.created", bad_handler)
+        bus.subscribe("order.created", good_handler)
+        await bus.publish(Event("order.created"))
+        assert second_called  # good handler still ran
+
+    @pytest.mark.asyncio
+    async def test_no_handlers_publishes_silently(self):
+        bus = EventBus()
+        # No handlers registered — should not raise
+        await bus.publish(Event("unknown.event"))
+        assert len(bus.published) == 1
+
+
+# ---------------------------------------------------------------------------
+# @on_event decorator
+# ---------------------------------------------------------------------------
+
+
+class TestOnEventDecorator:
+    def test_marks_method_with_event_type(self):
+        @on_event("order.created")
+        async def handler(self, event):
+            pass
+
+        assert get_event_type(handler) == "order.created"
+
+    def test_marks_wildcard(self):
+        @on_event("*")
+        async def handler(self, event):
+            pass
+
+        assert get_event_type(handler) == "*"
+
+    def test_plain_method_has_no_event_type(self):
+        async def handler(self, event):
+            pass
+
+        assert get_event_type(handler) is None
+
+
+# ---------------------------------------------------------------------------
+# ChoreographedSaga
+# ---------------------------------------------------------------------------
+
+
+class TestChoreographedSaga:
+    def test_discovers_handlers_on_init(self):
+        class OrderSaga(ChoreographedSaga):
+            @on_event("order.created")
+            async def handle_order(self, event: Event) -> None:
+                pass
+
+        saga = OrderSaga()
+        assert "order.created" in saga._handlers
+
+    def test_handles_returns_true_for_registered_event(self):
+        class MySaga(ChoreographedSaga):
+            @on_event("payment.charged")
+            async def handle(self, event: Event) -> None:
+                pass
+
+        saga = MySaga()
+        assert saga.handles("payment.charged")
+        assert not saga.handles("unknown.event")
+
+    @pytest.mark.asyncio
+    async def test_handle_dispatches_to_handler(self):
+        results = []
+
+        class MySaga(ChoreographedSaga):
+            @on_event("order.created")
+            async def handle_order(self, event: Event) -> None:
+                results.append(event.data.get("order_id"))
+
+        saga = MySaga()
+        await saga.handle(Event("order.created", {"order_id": "ORD-99"}))
+        assert results == ["ORD-99"]
+
+    @pytest.mark.asyncio
+    async def test_handle_ignores_unregistered_events(self):
+        class MySaga(ChoreographedSaga):
+            @on_event("order.created")
+            async def handle_order(self, event: Event) -> None:
+                pass
+
+        saga = MySaga()
+        # Should not raise
+        await saga.handle(Event("payment.charged", {}))
+        assert len(saga.events_handled) == 0
+
+    @pytest.mark.asyncio
+    async def test_wildcard_handler_receives_any_event(self):
+        received = []
+
+        class MySaga(ChoreographedSaga):
+            @on_event("*")
+            async def handle_all(self, event: Event) -> None:
+                received.append(event.event_type)
+
+        saga = MySaga()
+        await saga.handle(Event("order.created"))
+        await saga.handle(Event("payment.failed"))
+        assert received == ["order.created", "payment.failed"]
+
+    def test_events_handled_tracks_dispatched_events(self):
+        class MySaga(ChoreographedSaga):
+            @on_event("order.created")
+            async def handle_order(self, event: Event) -> None:
+                pass
+
+        saga = MySaga()
+        asyncio.get_event_loop().run_until_complete(saga.handle(Event("order.created")))
+        assert len(saga.events_handled) == 1
+
+    def test_default_saga_id_is_assigned(self):
+        saga = ChoreographedSaga()
+        assert saga.saga_id
+        assert len(saga.saga_id) > 0
+
+    def test_custom_saga_id_preserved(self):
+        saga = ChoreographedSaga(saga_id="custom-123")
+        assert saga.saga_id == "custom-123"
+
+
+# ---------------------------------------------------------------------------
+# ChoreographyEngine
+# ---------------------------------------------------------------------------
+
+
+class TestChoreographyEngine:
+    @pytest.mark.asyncio
+    async def test_start_and_stop(self):
+        bus = EventBus()
+        engine = ChoreographyEngine(bus)
+        assert not engine.is_running
+        await engine.start()
+        assert engine.is_running
+        await engine.stop()
+        assert not engine.is_running
+
+    @pytest.mark.asyncio
+    async def test_register_wires_handlers(self):
+        bus = EventBus()
+        engine = ChoreographyEngine(bus)
+        results = []
+
+        class MySaga(ChoreographedSaga):
+            @on_event("order.created")
+            async def handle_order(self, event: Event) -> None:
+                results.append(event.data.get("order_id"))
+
+        engine.register(MySaga(saga_id="s1"))
+        await engine.start()
+        await bus.publish(Event("order.created", {"order_id": "ORD-1"}))
+        await engine.stop()
+        assert "ORD-1" in results
+
+    @pytest.mark.asyncio
+    async def test_multiple_sagas_receive_same_event(self):
+        bus = EventBus()
+        engine = ChoreographyEngine(bus)
+        received = []
+
+        class SagaA(ChoreographedSaga):
+            @on_event("payment.charged")
+            async def handle(self, event: Event) -> None:
+                received.append("A")
+
+        class SagaB(ChoreographedSaga):
+            @on_event("payment.charged")
+            async def handle(self, event: Event) -> None:
+                received.append("B")
+
+        engine.register(SagaA(saga_id="a"))
+        engine.register(SagaB(saga_id="b"))
+        await engine.start()
+        await bus.publish(Event("payment.charged"))
+        await engine.stop()
+        assert set(received) == {"A", "B"}
+
+    @pytest.mark.asyncio
+    async def test_unregister_removes_saga(self):
+        bus = EventBus()
+        engine = ChoreographyEngine(bus)
+
+        class MySaga(ChoreographedSaga):
+            @on_event("order.created")
+            async def handle(self, event: Event) -> None:
+                pass
+
+        engine.register(MySaga(saga_id="s1"))
+        engine.unregister("s1")
+        assert engine.get_saga("s1") is None
+
+    @pytest.mark.asyncio
+    async def test_registered_sagas_list(self):
+        bus = EventBus()
+        engine = ChoreographyEngine(bus)
+        engine.register(ChoreographedSaga(saga_id="s1"))
+        engine.register(ChoreographedSaga(saga_id="s2"))
+        assert len(engine.registered_sagas) == 2
+
+    @pytest.mark.asyncio
+    async def test_end_to_end_chain(self):
+        """
+        Chain: order.created → inventory.reserve → payment.initiate → order.confirmed
+        """
+        bus = EventBus()
+        engine = ChoreographyEngine(bus)
+        trace: list[str] = []
+
+        class InventorySaga(ChoreographedSaga):
+            @on_event("order.created")
+            async def reserve(self, event: Event) -> None:
+                trace.append("inventory.reserved")
+                await bus.publish(Event("inventory.reserved", event.data))
+
+        class PaymentSaga(ChoreographedSaga):
+            @on_event("inventory.reserved")
+            async def charge(self, event: Event) -> None:
+                trace.append("payment.charged")
+                await bus.publish(Event("payment.charged", event.data))
+
+        class NotificationSaga(ChoreographedSaga):
+            @on_event("payment.charged")
+            async def notify(self, event: Event) -> None:
+                trace.append("order.confirmed")
+
+        engine.register(InventorySaga(saga_id="inv"))
+        engine.register(PaymentSaga(saga_id="pay"))
+        engine.register(NotificationSaga(saga_id="notif"))
+        await engine.start()
+        await bus.publish(Event("order.created", {"order_id": "ORD-42"}))
+        await engine.stop()
+
+        assert trace == ["inventory.reserved", "payment.charged", "order.confirmed"]

--- a/tests/unit/test_choreography.py
+++ b/tests/unit/test_choreography.py
@@ -170,6 +170,25 @@ class TestEventBus:
         await bus.start()
         await bus.stop()
 
+    def test_abstract_eventbus_default_published_and_handler_count(self):
+        """AbstractEventBus default published/handler_count return empty values."""
+        from sagaz.choreography.events import AbstractEventBus
+
+        class _MinimalBus(AbstractEventBus):
+            async def publish(self, event: Event) -> None:  # type: ignore[override]
+                pass
+
+            def subscribe(self, event_type: str, handler) -> None:  # type: ignore[override]
+                pass
+
+            def unsubscribe(self, event_type: str, handler) -> None:  # type: ignore[override]
+                pass
+
+        bus = _MinimalBus()
+        assert bus.published == []
+        assert bus.handler_count("any") == 0
+        bus.clear_history()  # must not raise
+
 
 # ---------------------------------------------------------------------------
 # @on_event decorator
@@ -444,3 +463,41 @@ class TestChoreographyEngine:
         await engine.stop()
 
         assert calls == 1, f"Expected 1 call, got {calls} (duplicate handler registered)"
+
+    @pytest.mark.asyncio
+    async def test_unregister_nonexistent_saga_id_is_noop(self):
+        """Calling unregister() for an unknown saga_id must not raise."""
+        bus = EventBus()
+        engine = ChoreographyEngine(bus)
+        engine.unregister("does-not-exist")  # must not raise
+
+    def test_duplicate_event_type_logs_warning(self):
+        """Two @on_event handlers for the same event type trigger a warning."""
+        import logging
+
+        import sagaz.choreography.saga as saga_mod
+
+        class DuplicateSaga(ChoreographedSaga):
+            @on_event("same.event")
+            async def handler_one(self, event: Event) -> None:
+                pass
+
+            @on_event("same.event")
+            async def handler_two(self, event: Event) -> None:
+                pass
+
+        records: list[logging.LogRecord] = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                records.append(record)
+
+        cap = _Capture()
+        saga_mod.logger.addHandler(cap)
+        try:
+            DuplicateSaga(saga_id="dup-1")
+        finally:
+            saga_mod.logger.removeHandler(cap)
+
+        warning_records = [r for r in records if r.levelno == logging.WARNING]
+        assert any("multiple handlers" in r.getMessage() for r in warning_records)

--- a/tests/unit/test_choreography.py
+++ b/tests/unit/test_choreography.py
@@ -102,7 +102,7 @@ class TestEventBus:
 
     def test_clear_history(self):
         bus = EventBus()
-        asyncio.get_event_loop().run_until_complete(bus.publish(Event("x")))
+        asyncio.run(bus.publish(Event("x")))
         bus.clear_history()
         assert bus.published == []
 
@@ -244,7 +244,7 @@ class TestChoreographedSaga:
                 pass
 
         saga = MySaga()
-        asyncio.get_event_loop().run_until_complete(saga.handle(Event("order.created")))
+        asyncio.run(saga.handle(Event("order.created")))
         assert len(saga.events_handled) == 1
 
     def test_default_saga_id_is_assigned(self):

--- a/tests/unit/test_choreography.py
+++ b/tests/unit/test_choreography.py
@@ -5,8 +5,6 @@ ChoreographyEngine, and @on_event decorator.
 
 from __future__ import annotations
 
-import asyncio
-
 import pytest
 
 from sagaz.choreography import (
@@ -47,6 +45,15 @@ class TestEvent:
     def test_repr_contains_type(self):
         e = Event("order.created")
         assert "order.created" in repr(e)
+
+    def test_with_saga_does_not_share_data_dict(self):
+        """with_saga() must return an independent copy of the data dict."""
+        original_data = {"order_id": "ORD-1"}
+        e = Event("order.created", original_data)
+        e2 = e.with_saga("saga-123")
+        # Mutations to one dict must not affect the other
+        original_data["order_id"] = "MUTATED"
+        assert e2.data["order_id"] == "ORD-1"
 
 
 # ---------------------------------------------------------------------------
@@ -100,9 +107,10 @@ class TestEventBus:
         await bus.publish(Event("payment.charged"))
         assert len(bus.published) == 2
 
-    def test_clear_history(self):
+    @pytest.mark.asyncio
+    async def test_clear_history(self):
         bus = EventBus()
-        asyncio.run(bus.publish(Event("x")))
+        await bus.publish(Event("x"))
         bus.clear_history()
         assert bus.published == []
 
@@ -144,6 +152,23 @@ class TestEventBus:
         # No handlers registered — should not raise
         await bus.publish(Event("unknown.event"))
         assert len(bus.published) == 1
+
+    def test_unsubscribe_nonexistent_handler_is_silent(self):
+        """Unsubscribing a handler that was never registered must not raise."""
+        bus = EventBus()
+
+        async def never_subscribed(e: Event) -> None:
+            pass
+
+        # Must not raise ValueError
+        bus.unsubscribe("order.created", never_subscribed)
+
+    @pytest.mark.asyncio
+    async def test_start_and_stop_are_noops(self):
+        """EventBus.start() and stop() are no-ops — must not raise."""
+        bus = EventBus()
+        await bus.start()
+        await bus.stop()
 
 
 # ---------------------------------------------------------------------------
@@ -237,14 +262,15 @@ class TestChoreographedSaga:
         await saga.handle(Event("payment.failed"))
         assert received == ["order.created", "payment.failed"]
 
-    def test_events_handled_tracks_dispatched_events(self):
+    @pytest.mark.asyncio
+    async def test_events_handled_tracks_dispatched_events(self):
         class MySaga(ChoreographedSaga):
             @on_event("order.created")
             async def handle_order(self, event: Event) -> None:
                 pass
 
         saga = MySaga()
-        asyncio.run(saga.handle(Event("order.created")))
+        await saga.handle(Event("order.created"))
         assert len(saga.events_handled) == 1
 
     def test_default_saga_id_is_assigned(self):
@@ -369,3 +395,52 @@ class TestChoreographyEngine:
         await engine.stop()
 
         assert trace == ["inventory.reserved", "payment.charged", "order.confirmed"]
+
+    @pytest.mark.asyncio
+    async def test_deregister_unsubscribes_handlers(self):
+        """After unregister, the saga no longer receives events from the bus."""
+        bus = EventBus()
+        engine = ChoreographyEngine(bus)
+        received: list[str] = []
+
+        class MySaga(ChoreographedSaga):
+            @on_event("order.created")
+            async def handle_order(self, event: Event) -> None:
+                received.append(event.data.get("id", ""))
+
+        saga = MySaga(saga_id="s1")
+        engine.register(saga)
+        await engine.start()
+
+        await bus.publish(Event("order.created", {"id": "before"}))
+        assert "before" in received
+
+        engine.unregister("s1")
+        received.clear()
+        await bus.publish(Event("order.created", {"id": "after"}))
+        assert "after" not in received, "Handler still called after unregister"
+
+        await engine.stop()
+
+    @pytest.mark.asyncio
+    async def test_re_register_replaces_old_handlers(self):
+        """Re-registering a saga with the same ID must not duplicate handler calls."""
+        bus = EventBus()
+        engine = ChoreographyEngine(bus)
+        calls = 0
+
+        class MySaga(ChoreographedSaga):
+            @on_event("x.event")
+            async def handle(self, event: Event) -> None:
+                nonlocal calls
+                calls += 1
+
+        # Register the same saga ID twice — second call should replace the first.
+        engine.register(MySaga(saga_id="s1"))
+        engine.register(MySaga(saga_id="s1"))
+        await engine.start()
+
+        await bus.publish(Event("x.event"))
+        await engine.stop()
+
+        assert calls == 1, f"Expected 1 call, got {calls} (duplicate handler registered)"

--- a/tests/unit/test_kafka_bus.py
+++ b/tests/unit/test_kafka_bus.py
@@ -39,9 +39,7 @@ def _make_bus(config: KafkaEventBusConfig | None = None) -> KafkaEventBus:
     return KafkaEventBus(config or _make_config())
 
 
-def _make_event(
-    event_type: str = "order.created", saga_id: str | None = "s-1"
-) -> Event:
+def _make_event(event_type: str = "order.created", saga_id: str | None = "s-1") -> Event:
     return Event(event_type=event_type, data={"order_id": "ORD-1"}, saga_id=saga_id)
 
 
@@ -191,9 +189,7 @@ async def test_dispatch_calls_wildcard_handler() -> None:
         ("order.created", "*", True),
     ],
 )
-async def test_dispatch_routing(
-    event_type: str, subscribed_to: str, should_call: bool
-) -> None:
+async def test_dispatch_routing(event_type: str, subscribed_to: str, should_call: bool) -> None:
     bus = _make_bus()
     handler = AsyncMock()
     bus.subscribe(subscribed_to, handler)

--- a/tests/unit/test_kafka_bus.py
+++ b/tests/unit/test_kafka_bus.py
@@ -373,3 +373,157 @@ async def test_stop_closes_producer_and_consumer() -> None:
 async def test_stop_when_not_started_is_safe() -> None:
     bus = _make_bus()
     await bus.stop()  # Should not raise
+
+
+# ---------------------------------------------------------------------------
+# Import-error fallback (module-level except ImportError branch)
+# ---------------------------------------------------------------------------
+
+
+def test_kafka_import_error_sets_unavailable_flag() -> None:
+    """When aiokafka cannot be imported the module falls back gracefully."""
+    import importlib
+    import sys
+
+    import sagaz.choreography.buses.kafka as kmod
+
+    saved = sys.modules.pop("aiokafka", None)
+    sys.modules["aiokafka"] = None  # type: ignore[assignment]
+    try:
+        importlib.reload(kmod)
+        assert not kmod._KAFKA_AVAILABLE
+        assert kmod.AIOKafkaProducer is None
+        assert kmod.AIOKafkaConsumer is None
+    finally:
+        if saved is not None:
+            sys.modules["aiokafka"] = saved
+        else:
+            sys.modules.pop("aiokafka", None)
+        importlib.reload(kmod)  # Restore module to working state
+
+
+# ---------------------------------------------------------------------------
+# SASL configuration branch in start()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_with_sasl_mechanism_passes_sasl_options() -> None:
+    """start() must include SASL kwargs when sasl_mechanism is configured."""
+    config = KafkaEventBusConfig(
+        bootstrap_servers="broker:9093",
+        topic="test.topic",
+        consumer_group="grp",
+        consumer_name="w1",
+        sasl_mechanism="PLAIN",
+        sasl_username="user",
+        sasl_password="pass",
+        security_protocol="SASL_PLAINTEXT",
+    )
+    bus = _make_bus(config)
+    mock_producer = AsyncMock()
+    mock_consumer = AsyncMock()
+    mock_consumer.getmany = AsyncMock(side_effect=asyncio.CancelledError())
+
+    with (
+        patch(
+            "sagaz.choreography.buses.kafka.AIOKafkaProducer",
+            return_value=mock_producer,
+        ) as mock_producer_cls,
+        patch(
+            "sagaz.choreography.buses.kafka.AIOKafkaConsumer",
+            return_value=mock_consumer,
+        ) as mock_consumer_cls,
+    ):
+        await bus.start()
+        task = bus._reader_task
+        try:
+            await asyncio.wait_for(asyncio.shield(task), timeout=1.0)
+        except (asyncio.CancelledError, TimeoutError):
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+    # Both producer and consumer must have received SASL kwargs
+    _, producer_kwargs = mock_producer_cls.call_args
+    _, consumer_kwargs = mock_consumer_cls.call_args
+    for kwargs in (producer_kwargs, producer_kwargs):
+        assert kwargs.get("sasl_mechanism") == "PLAIN" or "sasl_mechanism" in str(
+            mock_producer_cls.call_args
+        )
+    assert "sasl_mechanism" in str(mock_producer_cls.call_args)
+    assert "sasl_mechanism" in str(mock_consumer_cls.call_args)
+
+
+# ---------------------------------------------------------------------------
+# _reader_loop coverage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reader_loop_cancelled_error_exits_cleanly() -> None:
+    """CancelledError from getmany causes reader loop to exit via break."""
+    bus = _make_bus()
+    bus._consumer = AsyncMock()
+    bus._consumer.getmany = AsyncMock(side_effect=asyncio.CancelledError())
+
+    # Task should complete normally (loop breaks on CancelledError)
+    await asyncio.wait_for(bus._reader_loop(), timeout=2.0)
+
+
+@pytest.mark.asyncio
+async def test_reader_loop_dispatches_messages() -> None:
+    """Reader loop commits each message after successful dispatch."""
+    bus = _make_bus()
+    handler = AsyncMock()
+    bus.subscribe("order.created", handler)
+
+    event = _make_event("order.created")
+    serialised = _serialise(event)
+
+    call_count = 0
+    tp = MagicMock()
+    msg = MagicMock()
+    msg.value = serialised
+    msg.offset = 0
+
+    async def fake_getmany(**kwargs: object) -> dict:  # type: ignore[type-arg]
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return {tp: [msg]}
+        raise asyncio.CancelledError
+
+    bus._consumer = AsyncMock()
+    bus._consumer.getmany = fake_getmany
+
+    await asyncio.wait_for(bus._reader_loop(), timeout=2.0)
+
+    handler.assert_awaited()
+    bus._consumer.commit.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reader_loop_exception_is_logged_and_loop_retries() -> None:
+    """Non-CancelledError exceptions are caught, logged, and the loop retries."""
+    bus = _make_bus()
+    bus._consumer = AsyncMock()
+
+    call_count = 0
+
+    async def fake_getmany(**kwargs: object) -> dict:  # type: ignore[type-arg]
+        nonlocal call_count
+        call_count += 1
+        msg = "broker gone"
+        if call_count == 1:
+            raise RuntimeError(msg)
+        raise asyncio.CancelledError
+
+    bus._consumer.getmany = fake_getmany
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await asyncio.wait_for(bus._reader_loop(), timeout=2.0)
+
+    assert call_count == 2

--- a/tests/unit/test_kafka_bus.py
+++ b/tests/unit/test_kafka_bus.py
@@ -1,0 +1,375 @@
+"""
+Unit tests for KafkaEventBus.
+
+aiokafka is fully mocked — no real Kafka broker required.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from sagaz.choreography.buses.kafka import (
+    KafkaEventBus,
+    KafkaEventBusConfig,
+    _event_to_value,
+    _value_to_event,
+)
+from sagaz.choreography.events import AbstractEventBus, Event
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config() -> KafkaEventBusConfig:
+    return KafkaEventBusConfig(
+        bootstrap_servers="localhost:9092",
+        topic="test.topic",
+        consumer_group="test-group",
+        consumer_name="test-worker",
+    )
+
+
+def _make_bus(config: KafkaEventBusConfig | None = None) -> KafkaEventBus:
+    return KafkaEventBus(config or _make_config())
+
+
+def _make_event(
+    event_type: str = "order.created", saga_id: str | None = "s-1"
+) -> Event:
+    return Event(event_type=event_type, data={"order_id": "ORD-1"}, saga_id=saga_id)
+
+
+def _serialise(event: Event) -> bytes:
+    return _event_to_value(event)
+
+
+# ---------------------------------------------------------------------------
+# Missing dependency guard
+# ---------------------------------------------------------------------------
+
+
+def test_missing_aiokafka_raises() -> None:
+    with patch("sagaz.choreography.buses.kafka._KAFKA_AVAILABLE", False):
+        from sagaz.core.exceptions import MissingDependencyError
+
+        with pytest.raises(MissingDependencyError, match="aiokafka"):
+            KafkaEventBus()
+
+
+# ---------------------------------------------------------------------------
+# ABC conformance
+# ---------------------------------------------------------------------------
+
+
+def test_kafka_bus_is_abstract_eventbus() -> None:
+    bus = _make_bus()
+    assert isinstance(bus, AbstractEventBus)
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+def test_from_env_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = KafkaEventBusConfig.from_env()
+    assert config.bootstrap_servers == "localhost:9092"
+    assert config.topic == "sagaz.choreography"
+    assert config.consumer_group == "sagaz"
+    assert config.consumer_name == "worker-1"
+
+
+def test_from_env_custom(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SAGAZ_BUS_KAFKA_BOOTSTRAP_SERVERS", "broker:9093")
+    monkeypatch.setenv("SAGAZ_BUS_KAFKA_TOPIC", "my.topic")
+    monkeypatch.setenv("SAGAZ_BUS_KAFKA_CONSUMER_GROUP", "my-group")
+    monkeypatch.setenv("SAGAZ_BUS_KAFKA_CONSUMER_NAME", "worker-99")
+    monkeypatch.setenv("SAGAZ_BUS_KAFKA_SASL_MECHANISM", "PLAIN")
+
+    config = KafkaEventBusConfig.from_env()
+    assert config.bootstrap_servers == "broker:9093"
+    assert config.topic == "my.topic"
+    assert config.consumer_group == "my-group"
+    assert config.consumer_name == "worker-99"
+    assert config.sasl_mechanism == "PLAIN"
+
+
+# ---------------------------------------------------------------------------
+# Serialisation round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_event_serialise_deserialise_round_trip() -> None:
+    original = _make_event()
+    recovered = _value_to_event(_event_to_value(original))
+    assert recovered.event_type == original.event_type
+    assert recovered.data == original.data
+    assert recovered.event_id == original.event_id
+    assert recovered.saga_id == original.saga_id
+
+
+def test_event_serialise_null_saga_id() -> None:
+    event = _make_event(saga_id=None)
+    recovered = _value_to_event(_event_to_value(event))
+    assert recovered.saga_id is None
+
+
+# ---------------------------------------------------------------------------
+# Subscribe / unsubscribe
+# ---------------------------------------------------------------------------
+
+
+def test_subscribe_registers_handler() -> None:
+    bus = _make_bus()
+    handler = AsyncMock()
+    bus.subscribe("order.created", handler)
+    assert bus.handler_count("order.created") == 1
+
+
+def test_unsubscribe_removes_handler() -> None:
+    bus = _make_bus()
+    handler = AsyncMock()
+    bus.subscribe("order.created", handler)
+    bus.unsubscribe("order.created", handler)
+    assert bus.handler_count("order.created") == 0
+
+
+def test_unsubscribe_nonexistent_is_silent() -> None:
+    bus = _make_bus()
+    bus.unsubscribe("order.created", AsyncMock())
+
+
+def test_wildcard_and_specific_handler_counts() -> None:
+    bus = _make_bus()
+    bus.subscribe("*", AsyncMock())
+    bus.subscribe("order.created", AsyncMock())
+    assert bus.handler_count("*") == 1
+    assert bus.handler_count("order.created") == 1
+
+
+# ---------------------------------------------------------------------------
+# Dispatch (internal)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dispatch_calls_exact_handler() -> None:
+    bus = _make_bus()
+    handler = AsyncMock()
+    bus.subscribe("order.created", handler)
+
+    await bus._dispatch(_serialise(_make_event("order.created")))
+
+    handler.assert_awaited_once()
+    dispatched: Event = handler.call_args.args[0]
+    assert dispatched.event_type == "order.created"
+    assert dispatched.saga_id == "s-1"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_calls_wildcard_handler() -> None:
+    bus = _make_bus()
+    wildcard = AsyncMock()
+    bus.subscribe("*", wildcard)
+
+    await bus._dispatch(_serialise(_make_event("payment.initiated")))
+    wildcard.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("event_type", "subscribed_to", "should_call"),
+    [
+        ("order.created", "order.created", True),
+        ("order.created", "payment.initiated", False),
+        ("order.created", "*", True),
+    ],
+)
+async def test_dispatch_routing(
+    event_type: str, subscribed_to: str, should_call: bool
+) -> None:
+    bus = _make_bus()
+    handler = AsyncMock()
+    bus.subscribe(subscribed_to, handler)
+
+    await bus._dispatch(_serialise(_make_event(event_type)))
+
+    if should_call:
+        handler.assert_awaited_once()
+    else:
+        handler.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_handler_error_does_not_propagate() -> None:
+    bus = _make_bus()
+    bad = AsyncMock(side_effect=ValueError("boom"))
+    good = AsyncMock()
+    bus.subscribe("order.created", bad)
+    bus.subscribe("order.created", good)
+
+    await bus._dispatch(_serialise(_make_event()))
+
+    good.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_malformed_value_is_skipped() -> None:
+    bus = _make_bus()
+    handler = AsyncMock()
+    bus.subscribe("*", handler)
+
+    await bus._dispatch(b"not-json")
+    handler.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Publish
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_publish_without_start_raises() -> None:
+    bus = _make_bus()
+    with pytest.raises(RuntimeError, match="start()"):
+        await bus.publish(_make_event())
+
+
+@pytest.mark.asyncio
+async def test_publish_calls_send_and_wait_with_correct_topic_and_key() -> None:
+    bus = _make_bus()
+    mock_producer = AsyncMock()
+    bus._producer = mock_producer
+
+    event = _make_event("order.created")
+    await bus.publish(event)
+
+    mock_producer.send_and_wait.assert_awaited_once()
+    _, kwargs = mock_producer.send_and_wait.call_args
+    # First positional arg is the topic
+    topic = mock_producer.send_and_wait.call_args.args[0]
+    assert topic == "test.topic"
+    assert kwargs["key"] == b"order.created"
+    payload = json.loads(kwargs["value"].decode())
+    assert payload["event_type"] == "order.created"
+    assert payload["data"]["order_id"] == "ORD-1"
+
+
+@pytest.mark.asyncio
+async def test_publish_records_history() -> None:
+    bus = _make_bus()
+    bus._producer = AsyncMock()
+    event = _make_event()
+    await bus.publish(event)
+    assert event in bus.published
+
+
+@pytest.mark.asyncio
+async def test_clear_history() -> None:
+    bus = _make_bus()
+    bus._producer = AsyncMock()
+    await bus.publish(_make_event())
+    bus.clear_history()
+    assert bus.published == []
+
+
+# ---------------------------------------------------------------------------
+# Start / stop lifecycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_creates_producer_consumer_and_reader_task() -> None:
+    bus = _make_bus()
+    mock_producer = AsyncMock()
+    mock_consumer = AsyncMock()
+    # getmany must block briefly to avoid tight loop during test
+    mock_consumer.getmany = AsyncMock(return_value={})
+
+    with (
+        patch(
+            "sagaz.choreography.buses.kafka.AIOKafkaProducer",
+            return_value=mock_producer,
+        ),
+        patch(
+            "sagaz.choreography.buses.kafka.AIOKafkaConsumer",
+            return_value=mock_consumer,
+        ),
+    ):
+        await bus.start()
+
+    assert bus._reader_task is not None
+    assert not bus._reader_task.done()
+    bus._reader_task.cancel()
+    try:
+        await bus._reader_task
+    except asyncio.CancelledError:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_start_is_idempotent() -> None:
+    """Calling start() twice should not create a second reader task."""
+    bus = _make_bus()
+    mock_producer = AsyncMock()
+    mock_consumer = AsyncMock()
+    mock_consumer.getmany = AsyncMock(return_value={})
+
+    with (
+        patch(
+            "sagaz.choreography.buses.kafka.AIOKafkaProducer",
+            return_value=mock_producer,
+        ),
+        patch(
+            "sagaz.choreography.buses.kafka.AIOKafkaConsumer",
+            return_value=mock_consumer,
+        ),
+    ):
+        await bus.start()
+        first_task = bus._reader_task
+        await bus.start()  # second call is a no-op
+
+    assert bus._reader_task is first_task
+    first_task.cancel()
+    try:
+        await first_task
+    except asyncio.CancelledError:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_stop_closes_producer_and_consumer() -> None:
+    bus = _make_bus()
+    mock_producer = AsyncMock()
+    mock_consumer = AsyncMock()
+    mock_consumer.getmany = AsyncMock(return_value={})
+
+    with (
+        patch(
+            "sagaz.choreography.buses.kafka.AIOKafkaProducer",
+            return_value=mock_producer,
+        ),
+        patch(
+            "sagaz.choreography.buses.kafka.AIOKafkaConsumer",
+            return_value=mock_consumer,
+        ),
+    ):
+        await bus.start()
+        await bus.stop()
+
+    mock_producer.stop.assert_awaited_once()
+    mock_consumer.stop.assert_awaited_once()
+    assert bus._producer is None
+    assert bus._consumer is None
+
+
+@pytest.mark.asyncio
+async def test_stop_when_not_started_is_safe() -> None:
+    bus = _make_bus()
+    await bus.stop()  # Should not raise

--- a/tests/unit/test_rabbitmq_bus.py
+++ b/tests/unit/test_rabbitmq_bus.py
@@ -367,3 +367,30 @@ async def test_stop_cancels_consumer_and_closes_connection() -> None:
 async def test_stop_when_not_started_is_safe() -> None:
     bus = _make_bus()
     await bus.stop()  # Should not raise
+
+
+# ---------------------------------------------------------------------------
+# Import-error fallback (module-level except ImportError branch)
+# ---------------------------------------------------------------------------
+
+
+def test_rabbitmq_import_error_sets_unavailable_flag() -> None:
+    """When aio_pika cannot be imported the module falls back gracefully."""
+    import importlib
+    import sys
+
+    import sagaz.choreography.buses.rabbitmq as rmod
+
+    saved = sys.modules.pop("aio_pika", None)
+    sys.modules["aio_pika"] = None  # type: ignore[assignment]
+    try:
+        importlib.reload(rmod)
+        assert not rmod._RABBITMQ_AVAILABLE
+        assert rmod.aio_pika is None
+        assert rmod.Message is None
+    finally:
+        if saved is not None:
+            sys.modules["aio_pika"] = saved
+        else:
+            sys.modules.pop("aio_pika", None)
+        importlib.reload(rmod)  # Restore module to working state

--- a/tests/unit/test_rabbitmq_bus.py
+++ b/tests/unit/test_rabbitmq_bus.py
@@ -35,9 +35,7 @@ def _make_bus(config: RabbitMQEventBusConfig | None = None) -> RabbitMQEventBus:
     return RabbitMQEventBus(config or _make_config())
 
 
-def _make_event(
-    event_type: str = "order.created", saga_id: str | None = "s-1"
-) -> Event:
+def _make_event(event_type: str = "order.created", saga_id: str | None = "s-1") -> Event:
     return Event(event_type=event_type, data={"order_id": "ORD-1"}, saga_id=saga_id)
 
 
@@ -183,9 +181,7 @@ async def test_on_message_calls_wildcard_handler() -> None:
         ("order.created", "*", True),
     ],
 )
-async def test_on_message_routing(
-    event_type: str, subscribed_to: str, should_call: bool
-) -> None:
+async def test_on_message_routing(event_type: str, subscribed_to: str, should_call: bool) -> None:
     bus = _make_bus()
     handler = AsyncMock()
     bus.subscribe(subscribed_to, handler)

--- a/tests/unit/test_rabbitmq_bus.py
+++ b/tests/unit/test_rabbitmq_bus.py
@@ -1,0 +1,369 @@
+"""
+Unit tests for RabbitMQEventBus.
+
+aio-pika is fully mocked — no real RabbitMQ broker required.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from sagaz.choreography.buses.rabbitmq import (
+    RabbitMQEventBus,
+    RabbitMQEventBusConfig,
+)
+from sagaz.choreography.events import AbstractEventBus, Event
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config() -> RabbitMQEventBusConfig:
+    return RabbitMQEventBusConfig(
+        url="amqp://guest:guest@localhost/",
+        exchange_name="test.exchange",
+        queue_name="test.queue",
+    )
+
+
+def _make_bus(config: RabbitMQEventBusConfig | None = None) -> RabbitMQEventBus:
+    return RabbitMQEventBus(config or _make_config())
+
+
+def _make_event(
+    event_type: str = "order.created", saga_id: str | None = "s-1"
+) -> Event:
+    return Event(event_type=event_type, data={"order_id": "ORD-1"}, saga_id=saga_id)
+
+
+def _build_amqp_message(event: Event) -> MagicMock:
+    """Build a mock aio-pika message with the event as JSON body."""
+    payload = json.dumps(
+        {
+            "event_type": event.event_type,
+            "data": event.data,
+            "event_id": event.event_id,
+            "saga_id": event.saga_id,
+            "created_at": event.created_at.isoformat(),
+        }
+    ).encode()
+    msg = MagicMock()
+    msg.body = payload
+    # Simulate `async with message.process():` context manager
+    msg.process.return_value.__aenter__ = AsyncMock(return_value=None)
+    msg.process.return_value.__aexit__ = AsyncMock(return_value=None)
+    return msg
+
+
+# ---------------------------------------------------------------------------
+# Missing dependency guard
+# ---------------------------------------------------------------------------
+
+
+def test_missing_aio_pika_raises() -> None:
+    with patch("sagaz.choreography.buses.rabbitmq._RABBITMQ_AVAILABLE", False):
+        from sagaz.core.exceptions import MissingDependencyError
+
+        with pytest.raises(MissingDependencyError, match="aio-pika"):
+            RabbitMQEventBus()
+
+
+# ---------------------------------------------------------------------------
+# ABC conformance
+# ---------------------------------------------------------------------------
+
+
+def test_rabbitmq_bus_is_abstract_eventbus() -> None:
+    bus = _make_bus()
+    assert isinstance(bus, AbstractEventBus)
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+def test_from_env_defaults() -> None:
+    config = RabbitMQEventBusConfig.from_env()
+    assert config.url == "amqp://guest:guest@localhost/"
+    assert config.exchange_name == "sagaz.choreography"
+    assert config.queue_name == "sagaz.choreography.queue"
+    assert config.prefetch_count == 100
+    assert config.heartbeat == 60
+
+
+def test_from_env_custom(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SAGAZ_BUS_RABBITMQ_URL", "amqp://user:pass@myhost/myvhost")
+    monkeypatch.setenv("SAGAZ_BUS_RABBITMQ_EXCHANGE", "my.exchange")
+    monkeypatch.setenv("SAGAZ_BUS_RABBITMQ_QUEUE", "my.queue")
+    monkeypatch.setenv("SAGAZ_BUS_RABBITMQ_PREFETCH", "50")
+    monkeypatch.setenv("SAGAZ_BUS_RABBITMQ_HEARTBEAT", "30")
+
+    config = RabbitMQEventBusConfig.from_env()
+    assert config.url == "amqp://user:pass@myhost/myvhost"
+    assert config.exchange_name == "my.exchange"
+    assert config.queue_name == "my.queue"
+    assert config.prefetch_count == 50
+    assert config.heartbeat == 30
+
+
+# ---------------------------------------------------------------------------
+# Subscribe / unsubscribe
+# ---------------------------------------------------------------------------
+
+
+def test_subscribe_registers_handler() -> None:
+    bus = _make_bus()
+    handler = AsyncMock()
+    bus.subscribe("order.created", handler)
+    assert bus.handler_count("order.created") == 1
+
+
+def test_unsubscribe_removes_handler() -> None:
+    bus = _make_bus()
+    handler = AsyncMock()
+    bus.subscribe("order.created", handler)
+    bus.unsubscribe("order.created", handler)
+    assert bus.handler_count("order.created") == 0
+
+
+def test_unsubscribe_nonexistent_is_silent() -> None:
+    bus = _make_bus()
+    bus.unsubscribe("order.created", AsyncMock())
+
+
+def test_wildcard_and_specific_handler_counts() -> None:
+    bus = _make_bus()
+    bus.subscribe("*", AsyncMock())
+    bus.subscribe("order.created", AsyncMock())
+    assert bus.handler_count("*") == 1
+    assert bus.handler_count("order.created") == 1
+
+
+# ---------------------------------------------------------------------------
+# Message dispatch (internal)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_on_message_calls_exact_handler() -> None:
+    bus = _make_bus()
+    handler = AsyncMock()
+    bus.subscribe("order.created", handler)
+
+    await bus._on_message(_build_amqp_message(_make_event("order.created")))
+
+    handler.assert_awaited_once()
+    dispatched: Event = handler.call_args.args[0]
+    assert dispatched.event_type == "order.created"
+    assert dispatched.saga_id == "s-1"
+
+
+@pytest.mark.asyncio
+async def test_on_message_calls_wildcard_handler() -> None:
+    bus = _make_bus()
+    wildcard = AsyncMock()
+    bus.subscribe("*", wildcard)
+
+    await bus._on_message(_build_amqp_message(_make_event("payment.initiated")))
+    wildcard.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("event_type", "subscribed_to", "should_call"),
+    [
+        ("order.created", "order.created", True),
+        ("order.created", "payment.initiated", False),
+        ("order.created", "*", True),
+    ],
+)
+async def test_on_message_routing(
+    event_type: str, subscribed_to: str, should_call: bool
+) -> None:
+    bus = _make_bus()
+    handler = AsyncMock()
+    bus.subscribe(subscribed_to, handler)
+
+    await bus._on_message(_build_amqp_message(_make_event(event_type)))
+
+    if should_call:
+        handler.assert_awaited_once()
+    else:
+        handler.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_on_message_handler_error_does_not_propagate() -> None:
+    bus = _make_bus()
+    bad = AsyncMock(side_effect=ValueError("boom"))
+    good = AsyncMock()
+    bus.subscribe("order.created", bad)
+    bus.subscribe("order.created", good)
+
+    await bus._on_message(_build_amqp_message(_make_event()))
+
+    good.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_on_message_null_saga_id() -> None:
+    bus = _make_bus()
+    handler = AsyncMock()
+    bus.subscribe("order.created", handler)
+
+    await bus._on_message(_build_amqp_message(_make_event(saga_id=None)))
+
+    dispatched: Event = handler.call_args.args[0]
+    assert dispatched.saga_id is None
+
+
+@pytest.mark.asyncio
+async def test_on_message_malformed_body_is_skipped() -> None:
+    bus = _make_bus()
+    handler = AsyncMock()
+    bus.subscribe("*", handler)
+
+    bad_msg = MagicMock()
+    bad_msg.body = b"not-json"
+    bad_msg.process.return_value.__aenter__ = AsyncMock(return_value=None)
+    bad_msg.process.return_value.__aexit__ = AsyncMock(return_value=None)
+
+    await bus._on_message(bad_msg)
+    handler.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Publish
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_publish_without_start_raises() -> None:
+    bus = _make_bus()
+    with pytest.raises(RuntimeError, match="start()"):
+        await bus.publish(_make_event())
+
+
+@pytest.mark.asyncio
+async def test_publish_calls_exchange_publish_with_routing_key() -> None:
+    bus = _make_bus()
+    mock_exchange = AsyncMock()
+    bus._exchange = mock_exchange
+
+    event = _make_event("order.created")
+    await bus.publish(event)
+
+    mock_exchange.publish.assert_awaited_once()
+    _, kwargs = mock_exchange.publish.call_args
+    assert kwargs["routing_key"] == "order.created"
+
+
+@pytest.mark.asyncio
+async def test_publish_records_history() -> None:
+    bus = _make_bus()
+    bus._exchange = AsyncMock()
+    event = _make_event()
+    await bus.publish(event)
+    assert event in bus.published
+
+
+@pytest.mark.asyncio
+async def test_clear_history() -> None:
+    bus = _make_bus()
+    bus._exchange = AsyncMock()
+    await bus.publish(_make_event())
+    bus.clear_history()
+    assert bus.published == []
+
+
+# ---------------------------------------------------------------------------
+# Start / stop lifecycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_declares_exchange_and_queue_and_binds() -> None:
+    bus = _make_bus()
+    mock_connection = AsyncMock()
+    mock_channel = AsyncMock()
+    mock_exchange = AsyncMock()
+    mock_queue = AsyncMock()
+    mock_queue.consume = AsyncMock(return_value="consumer-tag-1")
+
+    mock_connection.channel = AsyncMock(return_value=mock_channel)
+    mock_channel.declare_exchange = AsyncMock(return_value=mock_exchange)
+    mock_channel.declare_queue = AsyncMock(return_value=mock_queue)
+
+    with patch(
+        "sagaz.choreography.buses.rabbitmq.aio_pika.connect_robust",
+        return_value=mock_connection,
+    ):
+        await bus.start()
+
+    mock_channel.declare_exchange.assert_awaited_once()
+    mock_channel.declare_queue.assert_awaited_once()
+    mock_queue.bind.assert_awaited_once()
+    mock_queue.consume.assert_awaited_once()
+    assert bus._consumer_tag == "consumer-tag-1"
+
+
+@pytest.mark.asyncio
+async def test_start_is_idempotent() -> None:
+    """A second call to start() when already connected should be a no-op."""
+    bus = _make_bus()
+    mock_connection = AsyncMock()
+    mock_channel = AsyncMock()
+    mock_queue = AsyncMock()
+    mock_queue.consume = AsyncMock(return_value="tag")
+
+    mock_connection.channel = AsyncMock(return_value=mock_channel)
+    mock_channel.declare_exchange = AsyncMock(return_value=AsyncMock())
+    mock_channel.declare_queue = AsyncMock(return_value=mock_queue)
+
+    with patch(
+        "sagaz.choreography.buses.rabbitmq.aio_pika.connect_robust",
+        return_value=mock_connection,
+    ) as mock_connect:
+        await bus.start()
+        await bus.start()  # second call should be no-op
+
+    assert mock_connect.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_stop_cancels_consumer_and_closes_connection() -> None:
+    bus = _make_bus()
+    mock_connection = AsyncMock()
+    mock_channel = AsyncMock()
+    mock_exchange = AsyncMock()
+    mock_queue = AsyncMock()
+    mock_queue.consume = AsyncMock(return_value="consumer-tag-1")
+
+    mock_connection.channel = AsyncMock(return_value=mock_channel)
+    mock_channel.declare_exchange = AsyncMock(return_value=mock_exchange)
+    mock_channel.declare_queue = AsyncMock(return_value=mock_queue)
+
+    with patch(
+        "sagaz.choreography.buses.rabbitmq.aio_pika.connect_robust",
+        return_value=mock_connection,
+    ):
+        await bus.start()
+        await bus.stop()
+
+    mock_queue.cancel.assert_awaited_once_with("consumer-tag-1")
+    mock_channel.close.assert_awaited_once()
+    mock_connection.close.assert_awaited_once()
+    assert bus._connection is None
+    assert bus._channel is None
+
+
+@pytest.mark.asyncio
+async def test_stop_when_not_started_is_safe() -> None:
+    bus = _make_bus()
+    await bus.stop()  # Should not raise

--- a/tests/unit/test_redis_streams_bus.py
+++ b/tests/unit/test_redis_streams_bus.py
@@ -1,0 +1,339 @@
+"""
+Unit tests for RedisStreamsEventBus.
+
+Redis is fully mocked — no real Redis server required.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from sagaz.choreography.buses import RedisStreamsBusConfig, RedisStreamsEventBus
+from sagaz.choreography.events import Event
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_bus(config: RedisStreamsBusConfig | None = None) -> RedisStreamsEventBus:
+    config = config or RedisStreamsBusConfig(
+        url="redis://localhost:6379/0",
+        stream_name="test.stream",
+        consumer_group="test-group",
+        consumer_name="test-worker",
+    )
+    return RedisStreamsEventBus(config)
+
+
+def _make_event(event_type: str = "order.created", saga_id: str | None = "s-1") -> Event:
+    return Event(
+        event_type=event_type,
+        data={"order_id": "ORD-1"},
+        saga_id=saga_id,
+    )
+
+
+def _serialise_event(event: Event) -> dict[bytes, bytes]:
+    """Build the bytes-keyed field dict that Redis returns."""
+    return {
+        b"event_type": event.event_type.encode(),
+        b"data": json.dumps(event.data).encode(),
+        b"event_id": event.event_id.encode(),
+        b"saga_id": (event.saga_id or "").encode(),
+        b"created_at": event.created_at.isoformat().encode(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Missing dependency guard
+# ---------------------------------------------------------------------------
+
+
+def test_missing_redis_raises() -> None:
+    """Constructor raises MissingDependencyError when redis is not installed."""
+    with patch("sagaz.choreography.buses.redis_streams._REDIS_AVAILABLE", False):
+        from sagaz.core.exceptions import MissingDependencyError
+
+        with pytest.raises(MissingDependencyError, match="redis"):
+            RedisStreamsEventBus()
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+def test_from_env_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = RedisStreamsBusConfig.from_env()
+    assert config.url == "redis://localhost:6379/0"
+    assert config.stream_name == "sagaz.choreography"
+    assert config.consumer_group == "sagaz"
+
+
+def test_from_env_custom(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SAGAZ_BUS_REDIS_URL", "redis://myhost:6380/1")
+    monkeypatch.setenv("SAGAZ_BUS_REDIS_STREAM_NAME", "my.stream")
+    monkeypatch.setenv("SAGAZ_BUS_REDIS_CONSUMER_GROUP", "my-group")
+    monkeypatch.setenv("SAGAZ_BUS_REDIS_CONSUMER_NAME", "worker-42")
+    monkeypatch.setenv("SAGAZ_BUS_REDIS_BLOCK_TIMEOUT_MS", "500")
+
+    config = RedisStreamsBusConfig.from_env()
+    assert config.url == "redis://myhost:6380/1"
+    assert config.stream_name == "my.stream"
+    assert config.consumer_group == "my-group"
+    assert config.consumer_name == "worker-42"
+    assert config.block_timeout_ms == 500
+
+
+# ---------------------------------------------------------------------------
+# Subscribe / unsubscribe
+# ---------------------------------------------------------------------------
+
+
+def test_subscribe_registers_handler() -> None:
+    bus = _make_bus()
+    handler = AsyncMock()
+    bus.subscribe("order.created", handler)
+    assert bus.handler_count("order.created") == 1
+
+
+def test_unsubscribe_removes_handler() -> None:
+    bus = _make_bus()
+    handler = AsyncMock()
+    bus.subscribe("order.created", handler)
+    bus.unsubscribe("order.created", handler)
+    assert bus.handler_count("order.created") == 0
+
+
+def test_unsubscribe_nonexistent_is_silent() -> None:
+    bus = _make_bus()
+    handler = AsyncMock()
+    # Should not raise
+    bus.unsubscribe("order.created", handler)
+
+
+def test_wildcard_handler_count() -> None:
+    bus = _make_bus()
+    h1, h2 = AsyncMock(), AsyncMock()
+    bus.subscribe("*", h1)
+    bus.subscribe("order.created", h2)
+    assert bus.handler_count("*") == 1
+    assert bus.handler_count("order.created") == 1
+
+
+# ---------------------------------------------------------------------------
+# Publish
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_publish_calls_xadd() -> None:
+    bus = _make_bus()
+    mock_client = AsyncMock()
+    bus._client = mock_client  # inject mock
+
+    event = _make_event()
+    await bus.publish(event)
+
+    mock_client.xadd.assert_awaited_once()
+    call_args = mock_client.xadd.call_args
+    stream_name, fields = call_args.args
+    assert stream_name == "test.stream"
+    assert fields["event_type"] == "order.created"
+    assert fields["saga_id"] == "s-1"
+    assert json.loads(fields["data"])["order_id"] == "ORD-1"
+
+
+@pytest.mark.asyncio
+async def test_publish_without_start_raises() -> None:
+    bus = _make_bus()
+    with pytest.raises(RuntimeError, match="start()"):
+        await bus.publish(_make_event())
+
+
+@pytest.mark.asyncio
+async def test_publish_records_history() -> None:
+    bus = _make_bus()
+    bus._client = AsyncMock()
+    event = _make_event()
+    await bus.publish(event)
+    assert event in bus.published
+
+
+@pytest.mark.asyncio
+async def test_clear_history() -> None:
+    bus = _make_bus()
+    bus._client = AsyncMock()
+    await bus.publish(_make_event())
+    bus.clear_history()
+    assert bus.published == []
+
+
+# ---------------------------------------------------------------------------
+# Dispatch (internal — unit test of the deserialise + handler routing)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dispatch_calls_exact_handler() -> None:
+    bus = _make_bus()
+    handler = AsyncMock()
+    bus.subscribe("order.created", handler)
+
+    event = _make_event("order.created")
+    fields = _serialise_event(event)
+    await bus._dispatch(fields)
+
+    handler.assert_awaited_once()
+    dispatched: Event = handler.call_args.args[0]
+    assert dispatched.event_type == "order.created"
+    assert dispatched.saga_id == "s-1"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_calls_wildcard_handler() -> None:
+    bus = _make_bus()
+    wildcard = AsyncMock()
+    bus.subscribe("*", wildcard)
+
+    await bus._dispatch(_serialise_event(_make_event("payment.initiated")))
+    wildcard.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("event_type", "subscribed_to", "should_call"),
+    [
+        ("order.created", "order.created", True),
+        ("order.created", "payment.initiated", False),
+        ("order.created", "*", True),
+    ],
+)
+async def test_dispatch_routing(
+    event_type: str, subscribed_to: str, should_call: bool
+) -> None:
+    bus = _make_bus()
+    handler = AsyncMock()
+    bus.subscribe(subscribed_to, handler)
+
+    await bus._dispatch(_serialise_event(_make_event(event_type)))
+
+    if should_call:
+        handler.assert_awaited_once()
+    else:
+        handler.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_handler_error_does_not_propagate() -> None:
+    """A failing handler must not prevent other handlers from running."""
+    bus = _make_bus()
+    bad_handler = AsyncMock(side_effect=ValueError("boom"))
+    good_handler = AsyncMock()
+    bus.subscribe("order.created", bad_handler)
+    bus.subscribe("order.created", good_handler)
+
+    await bus._dispatch(_serialise_event(_make_event()))
+
+    good_handler.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_null_saga_id() -> None:
+    """Events with no saga_id should deserialise with saga_id=None."""
+    bus = _make_bus()
+    handler = AsyncMock()
+    bus.subscribe("order.created", handler)
+
+    event = _make_event(saga_id=None)
+    await bus._dispatch(_serialise_event(event))
+
+    dispatched: Event = handler.call_args.args[0]
+    assert dispatched.saga_id is None
+
+
+@pytest.mark.asyncio
+async def test_dispatch_malformed_fields_skipped() -> None:
+    """A message with missing required fields should be silently skipped."""
+    bus = _make_bus()
+    handler = AsyncMock()
+    bus.subscribe("*", handler)
+
+    bad_fields: dict[bytes, bytes] = {b"junk": b"value"}
+    await bus._dispatch(bad_fields)
+
+    handler.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Start / stop lifecycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_creates_consumer_group_and_reader_task() -> None:
+    bus = _make_bus()
+    mock_client = AsyncMock()
+
+    with patch(
+        "sagaz.choreography.buses.redis_streams.aioredis.from_url",
+        return_value=mock_client,
+    ):
+        await bus.start()
+
+    assert bus._reader_task is not None
+    assert not bus._reader_task.done()
+    bus._reader_task.cancel()
+    try:
+        await bus._reader_task
+    except asyncio.CancelledError:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_start_handles_busygroup_error() -> None:
+    """BUSYGROUP should be silently ignored on second start."""
+    bus = _make_bus()
+    mock_client = AsyncMock()
+    mock_client.xgroup_create.side_effect = Exception("BUSYGROUP Consumer group already exists")
+
+    with patch(
+        "sagaz.choreography.buses.redis_streams.aioredis.from_url",
+        return_value=mock_client,
+    ):
+        await bus.start()  # Should not raise
+
+    bus._reader_task.cancel()
+    try:
+        await bus._reader_task
+    except asyncio.CancelledError:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_stop_cancels_reader_and_closes_client() -> None:
+    bus = _make_bus()
+    mock_client = AsyncMock()
+
+    with patch(
+        "sagaz.choreography.buses.redis_streams.aioredis.from_url",
+        return_value=mock_client,
+    ):
+        await bus.start()
+
+    await bus.stop()
+
+    mock_client.aclose.assert_awaited_once()
+    assert bus._client is None
+
+
+@pytest.mark.asyncio
+async def test_stop_when_not_started_is_safe() -> None:
+    bus = _make_bus()
+    await bus.stop()  # Should not raise

--- a/tests/unit/test_redis_streams_bus.py
+++ b/tests/unit/test_redis_streams_bus.py
@@ -215,9 +215,7 @@ async def test_dispatch_calls_wildcard_handler() -> None:
         ("order.created", "*", True),
     ],
 )
-async def test_dispatch_routing(
-    event_type: str, subscribed_to: str, should_call: bool
-) -> None:
+async def test_dispatch_routing(event_type: str, subscribed_to: str, should_call: bool) -> None:
     bus = _make_bus()
     handler = AsyncMock()
     bus.subscribe(subscribed_to, handler)

--- a/tests/unit/test_redis_streams_bus.py
+++ b/tests/unit/test_redis_streams_bus.py
@@ -337,3 +337,166 @@ async def test_stop_cancels_reader_and_closes_client() -> None:
 async def test_stop_when_not_started_is_safe() -> None:
     bus = _make_bus()
     await bus.stop()  # Should not raise
+
+
+# ---------------------------------------------------------------------------
+# Import-error fallback (module-level except ImportError branch)
+# ---------------------------------------------------------------------------
+
+
+def test_redis_import_error_sets_unavailable_flag() -> None:
+    """When redis cannot be imported the module falls back gracefully."""
+    import importlib
+    import sys
+
+    import sagaz.choreography.buses.redis_streams as rmod
+
+    saved = sys.modules.pop("redis", None)
+    saved_asyncio = sys.modules.pop("redis.asyncio", None)
+    sys.modules["redis"] = None  # type: ignore[assignment]
+    try:
+        importlib.reload(rmod)
+        assert not rmod._REDIS_AVAILABLE
+        assert rmod.aioredis is None
+    finally:
+        if saved is not None:
+            sys.modules["redis"] = saved
+        else:
+            sys.modules.pop("redis", None)
+        if saved_asyncio is not None:
+            sys.modules["redis.asyncio"] = saved_asyncio
+        else:
+            sys.modules.pop("redis.asyncio", None)
+        importlib.reload(rmod)  # Restore module to working state
+
+
+# ---------------------------------------------------------------------------
+# start() idempotency and non-BUSYGROUP error propagation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_is_idempotent() -> None:
+    """A second start() while the reader is running must be a no-op."""
+    bus = _make_bus()
+    mock_client = AsyncMock()
+
+    with patch(
+        "sagaz.choreography.buses.redis_streams.aioredis.from_url",
+        return_value=mock_client,
+    ):
+        await bus.start()
+        first_task = bus._reader_task
+        await bus.start()  # second call must not replace the task
+
+    assert bus._reader_task is first_task
+    first_task.cancel()
+    try:
+        await first_task
+    except asyncio.CancelledError:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_start_raises_non_busygroup_xgroup_error() -> None:
+    """xgroup_create errors not containing 'BUSYGROUP' must propagate."""
+    bus = _make_bus()
+    mock_client = AsyncMock()
+    mock_client.xgroup_create.side_effect = RuntimeError("unexpected redis error")
+
+    with patch(
+        "sagaz.choreography.buses.redis_streams.aioredis.from_url",
+        return_value=mock_client,
+    ):
+        with pytest.raises(RuntimeError, match="unexpected redis error"):
+            await bus.start()
+
+
+# ---------------------------------------------------------------------------
+# _reader_loop coverage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reader_loop_cancelled_error_exits_cleanly() -> None:
+    """CancelledError from xreadgroup causes reader loop to exit via break."""
+    bus = _make_bus()
+    bus._client = AsyncMock()
+    bus._client.xreadgroup = AsyncMock(side_effect=asyncio.CancelledError())
+
+    await asyncio.wait_for(bus._reader_loop(), timeout=2.0)
+
+
+@pytest.mark.asyncio
+async def test_reader_loop_empty_results_continues() -> None:
+    """Empty xreadgroup results cause the loop to continue without processing."""
+    bus = _make_bus()
+    bus._client = AsyncMock()
+
+    call_count = 0
+
+    async def fake_xreadgroup(*args: object, **kwargs: object) -> list:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return []  # empty — triggers `if not results: continue`
+        raise asyncio.CancelledError
+
+    bus._client.xreadgroup = fake_xreadgroup
+
+    await asyncio.wait_for(bus._reader_loop(), timeout=2.0)
+    assert call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_reader_loop_dispatches_messages() -> None:
+    """Reader loop acknowledges each message after successful dispatch."""
+    bus = _make_bus()
+    handler = AsyncMock()
+    bus.subscribe("order.created", handler)
+
+    event = _make_event("order.created")
+    fields = _serialise_event(event)
+    msg_id = b"1-0"
+
+    call_count = 0
+
+    async def fake_xreadgroup(*args: object, **kwargs: object) -> list:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            stream = b"test.stream"
+            return [(stream, [(msg_id, fields)])]
+        raise asyncio.CancelledError
+
+    bus._client = AsyncMock()
+    bus._client.xreadgroup = fake_xreadgroup
+
+    await asyncio.wait_for(bus._reader_loop(), timeout=2.0)
+
+    handler.assert_awaited()
+    bus._client.xack.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reader_loop_exception_is_logged_and_loop_retries() -> None:
+    """Non-CancelledError exceptions in xreadgroup are caught and retried."""
+    bus = _make_bus()
+    bus._client = AsyncMock()
+
+    call_count = 0
+
+    async def fake_xreadgroup(*args: object, **kwargs: object) -> list:
+        nonlocal call_count
+        call_count += 1
+        msg = "redis gone"
+        if call_count == 1:
+            raise RuntimeError(msg)
+        raise asyncio.CancelledError
+
+    bus._client.xreadgroup = fake_xreadgroup
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await asyncio.wait_for(bus._reader_loop(), timeout=2.0)
+
+    assert call_count == 2


### PR DESCRIPTION
## Changes

Event-driven choreography as an alternative to orchestration, with a **broker-agnostic** `AbstractEventBus` so any transport can back the saga event flow.  Implements ADR-029 (Saga Choreography).

## Motivation

Follows the roadmap defined in ADR-029. Additive — enables the capabilities described in the ADR without modifying any existing public API.

## What's in this PR

### Core abstractions
- `AbstractEventBus` — ABC shared by all transport backends (`sagaz.choreography.events`)
- `ChoreographedSaga` — base class for event-driven sagas
- `ChoreographyEngine` — wires sagas to any `AbstractEventBus`
- `@on_event` — event handler decorator

### Transport backends (all extend `AbstractEventBus`)
| Backend | Class | Extra required |
|---|---|---|
| In-process | `EventBus` | zero deps |
| Redis Streams | `RedisStreamsEventBus` | `sagaz[redis]` |
| Apache Kafka | `KafkaEventBus` | `sagaz[kafka]` |
| RabbitMQ / AMQP | `RabbitMQEventBus` | `sagaz[rabbitmq]` |

### Factory
```python
from sagaz.choreography import create_event_bus, BusBackend

bus = create_event_bus(BusBackend.KAFKA)
await bus.start()
bus.subscribe("order.created", handler)
await bus.publish(Event("order.created", {"order_id": "ORD-1"}))
await bus.stop()
```

## Tests (108 total, fully mocked — no containers required)
- 23 for `RedisStreamsEventBus`
- 26 for `KafkaEventBus`
- 24 for `RabbitMQEventBus`
- 7 for `create_event_bus` factory
- 29 for engine, in-process bus, and decorators

## Impact

Additive — new `sagaz.choreography` module and transport backends.  No changes to the existing orchestration API.

Closes #56
Closes #108