### PR TITLE
ci(ci): add maintenance workflow for automatic PR labeling

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,0 +1,118 @@
+name: Maintenance
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+# ─── Permissions ──────────────────────────────────────────────────────────────
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  # ─── Auto-label dependency PRs ─────────────────────────────────────────────
+  label-dependencies:
+    name: Label dependency PRs
+    runs-on: ubuntu-latest
+    # Only run for Dependabot or Renovate PRs
+    if: |
+      startsWith(github.head_ref, 'dependabot/') ||
+      startsWith(github.head_ref, 'renovate/')
+    steps:
+      - name: Apply "dependencies" label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pr_number = context.payload.pull_request.number;
+            const head = context.payload.pull_request.head.ref;
+
+            const labelMap = [
+              { prefix: 'dependabot/', label: 'dependencies' },
+              { prefix: 'renovate/',  label: 'dependencies' },
+            ];
+
+            const labelsToAdd = labelMap
+              .filter(({ prefix }) => head.startsWith(prefix))
+              .map(({ label }) => label);
+
+            if (labelsToAdd.length > 0) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: pr_number,
+                labels: [...new Set(labelsToAdd)],
+              });
+              core.info(`Applied labels: ${labelsToAdd.join(', ')} to PR #${pr_number}`);
+            }
+
+  # ─── Auto-label by branch prefix (extensible) ──────────────────────────────
+  label-by-branch:
+    name: Label PR by branch type
+    runs-on: ubuntu-latest
+    # Skip Dependabot/Renovate — handled above
+    if: |
+      !startsWith(github.head_ref, 'dependabot/') &&
+      !startsWith(github.head_ref, 'renovate/')
+    steps:
+      - name: Apply label matching branch prefix
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pr_number = context.payload.pull_request.number;
+            const head = context.payload.pull_request.head.ref;
+
+            // Map branch prefix -> label name (extend this list over time)
+            const prefixToLabel = {
+              'feature/':  'enhancement',
+              'fix/':      'bug',
+              'docs/':     'documentation',
+              'refactor/': 'refactor',
+              'test/':     'tests',
+              'ci/':       'ci',
+              'chore/':    'chore',
+            };
+
+            const match = Object.entries(prefixToLabel)
+              .find(([prefix]) => head.startsWith(prefix));
+
+            if (!match) {
+              core.info(`No label mapping found for branch: ${head}`);
+              return;
+            }
+
+            const [, label] = match;
+
+            // Ensure the label exists before applying (create if needed)
+            const labelColors = {
+              enhancement:  'a2eeef',
+              bug:          'd73a4a',
+              documentation:'0075ca',
+              refactor:     'fbca04',
+              tests:        '0e8a16',
+              ci:           '1d76db',
+              chore:        'ededed',
+            };
+
+            try {
+              await github.rest.issues.getLabel({ owner, repo, name: label });
+            } catch (e) {
+              if (e.status === 404) {
+                await github.rest.issues.createLabel({
+                  owner,
+                  repo,
+                  name: label,
+                  color: labelColors[label] || 'ededed',
+                });
+                core.info(`Created missing label: ${label}`);
+              }
+            }
+
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: pr_number,
+              labels: [label],
+            });
+            core.info(`Applied label '${label}' to PR #${pr_number} (branch: ${head})`);


### PR DESCRIPTION
## Changes

- Add `.github/workflows/maintenance.yml` with two jobs:
  - `label-dependencies`: applies the `dependencies` label to Dependabot and Renovate PRs
  - `label-by-branch`: applies typed labels (enhancement, bug, documentation, ci, chore, etc.) to feature PRs based on their branch prefix
- Extensible design: adding new label rules requires only a new entry in the `prefixToLabel` map

## Motivation

Dependency PRs were unlabeled, making triage and filtering difficult. Automatically applying labels at PR open/sync time ensures consistent categorization without manual intervention. The two-job split keeps dependency labeling and feature labeling independently evolvable.

## Impact

- All future Dependabot and Renovate PRs receive the `dependencies` label automatically
- Feature/fix/docs/ci branches receive matching typed labels
- Missing labels are auto-created (with sensible colours) so the workflow never fails on a new label name

Closes #99