### PR TITLE
docs(visualization): propose ADR-039 for Gradio UI Monitor

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -140,6 +140,7 @@ PR #42 (fix/coverage-and-container-timeouts)
 | D18–D22 | Apr 30–May 6 | Storage migration layer + transfer API | [#63](https://github.com/brunolnetto/sagaz/pull/63) / [#47](https://github.com/brunolnetto/sagaz/issues/47) | M2 |
 | D23–D30 | May 7–16 | sqldim analytics — Bronze reads + Silver star schema | [#74](https://github.com/brunolnetto/sagaz/pull/74) / [#73](https://github.com/brunolnetto/sagaz/issues/73) | M2 |
 | D31–D38 | May 19–28 | CLI v1.0 (`init`, `dev`, `status`, `logs`, `visualize`) | [#64](https://github.com/brunolnetto/sagaz/pull/64) / [#48](https://github.com/brunolnetto/sagaz/issues/48) | M3 |
+| D31–D35 | May 10–18 | **Gradio Asset Monitor** (ADR-039) | [#267](https://github.com/brunolnetto/sagaz/issues/267) | M3 |
 | D39–D52 | May 29–Jun 17 | Visualization UI — REST/SSE API + dashboard (Phases 1–3) | [#71](https://github.com/brunolnetto/sagaz/pull/71) / [#58](https://github.com/brunolnetto/sagaz/issues/58) | M3 |
 | D53–D57 | Jun 18–24 | sqldim Gold aggregations + UI analytics tab integration | [#74](https://github.com/brunolnetto/sagaz/pull/74) | M3 |
 | D58–D61 | Jun 25–30 | Integration testing, bugfix buffer, cut v1.5.0 / v1.6.0-beta | — | M3 |
@@ -151,6 +152,7 @@ PR #42 (fix/coverage-and-container-timeouts)
 | v1.5.0 | DLQ pattern, AlertManager rules | #60, #61 |
 | v1.6.0 | SQLite backend, storage migration | #62, #63 |
 | v1.7.0-beta | sqldim analytics pipeline (`sagaz[analytics]`) | #74 |
+| v1.7.0-beta | Gradio Asset Monitor UI (`sagaz[monitor]`) | #267 |
 | v1.7.0-beta | Visualization UI + live analytics tab | #71 |
 
 ### Deferred to Q3+ (Jul–Dec 2026)

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -40,6 +40,7 @@ This directory contains Architecture Decision Records (ADRs) documenting signifi
 | ADR | Title | Target | Description |
 |-----|-------|--------|-------------|
 | [ADR-029](adr-029-saga-choreography.md) | Saga Choreography Pattern | v2.2.0 | Event-driven distributed coordination |
+| [ADR-039](adr-039-gradio-ui-monitor.md) | Gradio-Based Saga Asset Monitor | v1.7.0 | Python-native monitoring UI for development |
 
 ### Medium / Low Priority
 

--- a/docs/architecture/adr/adr-039-gradio-ui-monitor.md
+++ b/docs/architecture/adr/adr-039-gradio-ui-monitor.md
@@ -1,0 +1,36 @@
+# ADR-039: Gradio-Based Saga Asset Monitor
+
+## Status
+Proposed (2026-04-24)
+
+## Context
+As the Sagaz ecosystem grows, developers need a zero-config, visual way to monitor saga assets (states, contexts, and dependency graphs) during development. While Grafana/Prometheus provide production-grade monitoring, they require a full infrastructure stack (database, metrics exporter, Grafana server).
+
+We need a lightweight, Python-native monitoring interface that can:
+1. Visualize the current state of any saga instance.
+2. Display the dependency graph (DAG) of a saga.
+3. Inspect the `SagaContext` in real-time.
+4. Run as a standalone tool or integrated into a dev server.
+
+## Decision
+We will implement a monitoring UI using **Gradio**. Gradio provides a rapid way to build interactive UIs in Python with minimal boilerplate, making it ideal for developer-centric tooling.
+
+The monitor will be accessible via:
+1. A new CLI command: `sagaz monitor --ui gradio`.
+2. A programmatic API: `sagaz.visualization.gradio.launch()`.
+
+### Technical Details
+- **Backend**: Uses existing `SagaStorage` interfaces to fetch data.
+- **Visualization**: Integrates with the existing Mermaid-based visualization engine.
+- **Portability**: Will be packaged as an optional extra `pip install sagaz[monitor]`.
+- **Interface**:
+    - Sidebar for saga instance selection.
+    - Central panel for Mermaid graph rendering.
+    - Data tables for context inspection.
+    - Real-time refresh using Gradio's state management.
+
+## Consequences
+- **Positive**: Simplifies local development and debugging of complex DAG sagas.
+- **Positive**: Low maintenance overhead compared to building a custom React/Vue frontend.
+- **Negative**: Adds a dependency on Gradio for those who want the UI.
+- **Neutral**: This tool is strictly for development/introspection and does not replace the production Grafana dashboard.

--- a/docs/architecture/adr/adr-039-gradio-ui-monitor.md
+++ b/docs/architecture/adr/adr-039-gradio-ui-monitor.md
@@ -1,36 +1,50 @@
 # ADR-039: Gradio-Based Saga Asset Monitor
 
 ## Status
-Proposed (2026-04-24)
+Proposed (2026-04-24) | Priority: High | Target: v1.7.0
 
 ## Context
-As the Sagaz ecosystem grows, developers need a zero-config, visual way to monitor saga assets (states, contexts, and dependency graphs) during development. While Grafana/Prometheus provide production-grade monitoring, they require a full infrastructure stack (database, metrics exporter, Grafana server).
+As the Sagaz ecosystem grows, developers need a zero-config, visual way to monitor saga assets (states, contexts, and dependency graphs) during development. ADR-035 previously proposed a custom FastAPI + Vanilla JS dashboard, but we want a more rapid, Python-native solution that fits better into the developer's workflow without building a custom frontend from scratch.
 
-We need a lightweight, Python-native monitoring interface that can:
-1. Visualize the current state of any saga instance.
-2. Display the dependency graph (DAG) of a saga.
-3. Inspect the `SagaContext` in real-time.
-4. Run as a standalone tool or integrated into a dev server.
+While Grafana/Prometheus provide production-grade monitoring, they require a full infrastructure stack. We need a lightweight, Python-native monitoring interface that can replicate the feature set proposed in ADR-035 but with the ease of Gradio.
 
 ## Decision
-We will implement a monitoring UI using **Gradio**. Gradio provides a rapid way to build interactive UIs in Python with minimal boilerplate, making it ideal for developer-centric tooling.
+We will implement a monitoring UI using **Gradio**. This replaces the custom JS frontend from ADR-035 with a Python-defined interface while maintaining all proposed features.
 
 The monitor will be accessible via:
 1. A new CLI command: `sagaz monitor --ui gradio`.
 2. A programmatic API: `sagaz.visualization.gradio.launch()`.
 
+### Feature Set (Parity with ADR-035)
+- **Dashboard Summary**: Cards showing total runs, success/failure rates, avg duration, and compensation rate.
+- **Saga Explorer**: A filterable table of all saga runs with status badges and timestamps.
+- **Instance Detail**:
+    - **Mermaid Graph**: Interactive diagram with status-based colour coding (green=done, red=failed, yellow=compensating).
+    - **Timeline View**: Step-by-step execution timeline with durations.
+    - **Context Inspector**: Collapsible JSON views for step inputs, outputs, and errors.
+- **Live Monitoring**: Automatic refresh of the UI as sagas execute (using Gradio's `every` or state-triggered updates).
+- **Comparison View**: Side-by-side comparison of two saga runs (e.g., comparing a successful run vs a failed run).
+
 ### Technical Details
-- **Backend**: Uses existing `SagaStorage` interfaces to fetch data.
+- **Backend**: Uses existing `SagaStorage` interfaces (Redis, Postgres, Memory).
 - **Visualization**: Integrates with the existing Mermaid-based visualization engine.
-- **Portability**: Will be packaged as an optional extra `pip install sagaz[monitor]`.
-- **Interface**:
-    - Sidebar for saga instance selection.
-    - Central panel for Mermaid graph rendering.
-    - Data tables for context inspection.
-    - Real-time refresh using Gradio's state management.
+- **Portability**: Packaged as an optional extra `pip install sagaz[monitor]`.
+- **Gradio Components**:
+    - `gr.Dataframe` for saga lists.
+    - `gr.HTML` for Mermaid diagram rendering.
+    - `gr.JSON` for context inspection.
+    - `gr.Plot` or `gr.BarPlot` for basic metrics.
 
 ## Consequences
-- **Positive**: Simplifies local development and debugging of complex DAG sagas.
-- **Positive**: Low maintenance overhead compared to building a custom React/Vue frontend.
-- **Negative**: Adds a dependency on Gradio for those who want the UI.
-- **Neutral**: This tool is strictly for development/introspection and does not replace the production Grafana dashboard.
+- **Positive**: 100% Python codebase for the UI, facilitating maintenance by the core team.
+- **Positive**: Faster implementation of complex interactive features (e.g., filtering, JSON tree exploration).
+- **Positive**: Direct integration with the Python debugger and logs.
+- **Negative**: Adds a dependency on `gradio` for the monitoring extra.
+- **Neutral**: Replaces the custom JS dashboard from ADR-035 as the primary developer tool, though the REST API from ADR-035 may still be implemented for third-party integrations (e.g., Grafana).
+
+## Cascaded Impact & Future Releases
+- **v1.7.0**: Initial Gradio UI with Dashboard, List, and Detail views (Phase 1).
+- **v1.8.0**: Advanced Live Monitoring and Historical Comparison (Phase 2).
+- **v2.0.0+**: Full integration with the production observability stack (ADR-035 Phase 5).
+
+This Gradio implementation will serve as the reference UI, while the REST/SSE API proposed in ADR-035 remains the target for production-grade, headless monitoring integrations.


### PR DESCRIPTION
## Motivation
Developers currently lack a zero-config, interactive way to monitor saga execution in real-time during development. While ADR-035 proposed a custom UI, a Python-native Gradio implementation (ADR-039) provides a faster, more maintainable path to the same feature set.

## Changes
- Added **ADR-039: Gradio-Based Saga Asset Monitor** proposing a Python-native monitoring UI.
- Achieved feature parity with ADR-035 (Dashboard, Saga Explorer, Instance Detail, Live Monitor, Context Inspector).
- Updated `docs/architecture/adr/README.md` to register the new ADR in the High Priority section.
- Updated `docs/ROADMAP.md` to schedule the Gradio Monitor for v1.7.0 (Milestone M3).

## Impact
- Provides a zero-setup visual debugger for Sagaz developers.
- Establishes the architectural foundation for a suite of Gradio-based monitoring tools.
- Cascaded impact on future releases:
  - **v1.7.0 (Current PR focus)**: ADR documentation and foundation.
  - **v1.7.0-beta**: Phase 1 implementation (Dashboard, Explorer, Detail).
  - **v1.8.0**: Phase 2 implementation (Live monitoring, Historical comparison).
  - **v2.0.0+**: Integration with production observability APIs and potential headless integrations.

Closes #267.
